### PR TITLE
Store extra case attributes from CaseCreated message

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/messaging/EventReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/EventReceiver.java
@@ -42,16 +42,27 @@ public class EventReceiver {
     Case newCase = new Case();
     newCase.setCaseRef(Long.parseLong(collectionCase.getCaseRef()));
     newCase.setCaseId(UUID.fromString(collectionCase.getId()));
-    newCase.setActionPlanId(collectionCase.getActionPlanId());
     newCase.setState(CaseState.valueOf(collectionCase.getState()));
-    newCase.setTreatmentCode(collectionCase.getTreatmentCode());
     newCase.setAddressLine1(collectionCase.getAddress().getAddressLine1());
     newCase.setAddressLine2(collectionCase.getAddress().getAddressLine2());
     newCase.setAddressLine3(collectionCase.getAddress().getAddressLine3());
     newCase.setTownName(collectionCase.getAddress().getTownName());
     newCase.setPostcode(collectionCase.getAddress().getPostcode());
+    newCase.setArid(collectionCase.getAddress().getArid());
+    newCase.setLatitude(collectionCase.getAddress().getLatitude());
+    newCase.setLongitude(collectionCase.getAddress().getLongitude());
+    newCase.setUprn(collectionCase.getAddress().getUprn());
+    newCase.setRgn(collectionCase.getAddress().getRegion());
 
-    // TODO: There are extra case attributes which we are not passed in the CollectionCase message
+    // Below this line is extra data potentially needed by Action Scheduler - can be ignored by RM
+    newCase.setActionPlanId(collectionCase.getActionPlanId()); // This is essential
+    newCase.setTreatmentCode(collectionCase.getTreatmentCode()); // This is essential
+    newCase.setOa(collectionCase.getOa());
+    newCase.setLsoa(collectionCase.getLsoa());
+    newCase.setMsoa(collectionCase.getMsoa());
+    newCase.setLad(collectionCase.getLad());
+    newCase.setHtcWillingness(collectionCase.getHtcWillingness());
+    newCase.setHtcDigital(collectionCase.getHtcDigital());
 
     caseRepository.save(newCase);
   }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
@@ -11,6 +11,14 @@ public class CollectionCase {
   private Address address;
   private String state;
   private String actionableFrom;
+
+  // Below this line is extra data potentially needed by Action Scheduler - can be ignored by RM
   private String actionPlanId;
   private String treatmentCode;
+  private String oa;
+  private String lsoa;
+  private String msoa;
+  private String lad;
+  private String htcWillingness;
+  private String htcDigital;
 }

--- a/src/test/java/uk.gov.ons.census.action/messaging/EventReceiverTest.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/EventReceiverTest.java
@@ -91,6 +91,17 @@ public class EventReceiverTest {
     newCase.setAddressLine3(collectionCase.getAddress().getAddressLine3());
     newCase.setTownName(collectionCase.getAddress().getTownName());
     newCase.setPostcode(collectionCase.getAddress().getPostcode());
+    newCase.setArid(collectionCase.getAddress().getArid());
+    newCase.setLatitude(collectionCase.getAddress().getLatitude());
+    newCase.setLongitude(collectionCase.getAddress().getLongitude());
+    newCase.setUprn(collectionCase.getAddress().getUprn());
+    newCase.setRgn(collectionCase.getAddress().getRegion());
+    newCase.setOa(collectionCase.getOa());
+    newCase.setLsoa(collectionCase.getLsoa());
+    newCase.setMsoa(collectionCase.getMsoa());
+    newCase.setLad(collectionCase.getLad());
+    newCase.setHtcWillingness(collectionCase.getHtcWillingness());
+    newCase.setHtcDigital(collectionCase.getHtcDigital());
 
     return newCase;
   }


### PR DESCRIPTION
# Motivation and Context
The Action Scheduler might have complex Action Rules based on multiple attributes of a case, so we should store as much data as possible to enable these rules to be created.

# What has changed
Added a bunch of extra data from the CaseCreated event, stored on the case.

# How to test?
Run the acceptance tests. Check the Action Scheduler case database and make sure all the rows are populated with data from the sample.

# Links
Trello: https://trello.com/c/R9CmkZGf/626-update-the-action-service-to-contain-new-attributes-8

# Screenshots (if appropriate):