### PR TITLE
Rename inbound queue

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
     virtualhost: /
 
 queueconfig:
-  inbound-queue: myfanout.actionqueue
+  inbound-queue: case.action
   outbound-printer-queue: Action.Printer
   outbound-exchange: action-outbound-exchange
   outbound-printer-routing-key: Action.Printer.binding


### PR DESCRIPTION
# Motivation and Context
The name of the queue from case processor to action scheduler has changed.

# What has changed
The name of the inbound queue.

# How to test?
Run the acceptance tests on the branch called `spike-topic-exchange` along with the Case Processor on the branch `spike-topic-exchange`.

# Links
Trello: https://trello.com/c/LQzjwQc2

# Screenshots (if appropriate):