### PR TITLE
Set all case attributes

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/messaging/EventReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/EventReceiver.java
@@ -43,6 +43,7 @@ public class EventReceiver {
     newCase.setCaseRef(Long.parseLong(collectionCase.getCaseRef()));
     newCase.setCaseId(UUID.fromString(collectionCase.getId()));
     newCase.setState(CaseState.valueOf(collectionCase.getState()));
+    newCase.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
     newCase.setAddressLine1(collectionCase.getAddress().getAddressLine1());
     newCase.setAddressLine2(collectionCase.getAddress().getAddressLine2());
     newCase.setAddressLine3(collectionCase.getAddress().getAddressLine3());
@@ -54,9 +55,16 @@ public class EventReceiver {
     newCase.setUprn(collectionCase.getAddress().getUprn());
     newCase.setRgn(collectionCase.getAddress().getRegion());
 
-    // Below this line is extra data potentially needed by Action Scheduler - can be ignored by RM
+    // Below this line is extra data potentially needed by Action Scheduler - can be ignored by RH
     newCase.setActionPlanId(collectionCase.getActionPlanId()); // This is essential
     newCase.setTreatmentCode(collectionCase.getTreatmentCode()); // This is essential
+    newCase.setAddressLevel(collectionCase.getAddress().getAddressLevel());
+    newCase.setAbpCode(collectionCase.getAddress().getApbCode());
+    newCase.setAddressType(collectionCase.getAddress().getAddressType());
+    newCase.setUprn(collectionCase.getAddress().getUprn());
+    newCase.setEstabArid(collectionCase.getAddress().getEstabArid());
+    newCase.setEstabType(collectionCase.getAddress().getEstabType());
+    newCase.setOrganisationName(collectionCase.getAddress().getOrganisationName());
     newCase.setOa(collectionCase.getOa());
     newCase.setLsoa(collectionCase.getLsoa());
     newCase.setMsoa(collectionCase.getMsoa());

--- a/src/main/java/uk/gov/ons/census/action/model/dto/Address.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/Address.java
@@ -13,7 +13,11 @@ public class Address {
   private String latitude;
   private String longitude;
   private String uprn;
+  private String apbCode;
   private String arid;
+  private String estabArid;
   private String addressType;
+  private String addressLevel;
   private String estabType;
+  private String organisationName;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
@@ -12,7 +12,7 @@ public class CollectionCase {
   private String state;
   private String actionableFrom;
 
-  // Below this line is extra data potentially needed by Action Scheduler - can be ignored by RM
+  // Below this line is extra data potentially needed by Action Scheduler - can be ignored by RH
   private String actionPlanId;
   private String treatmentCode;
   private String oa;

--- a/src/test/java/uk.gov.ons.census.action/messaging/EventReceiverTest.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/EventReceiverTest.java
@@ -84,6 +84,7 @@ public class EventReceiverTest {
     newCase.setCaseRef(Long.parseLong(collectionCase.getCaseRef()));
     newCase.setCaseId(UUID.fromString(collectionCase.getId()));
     newCase.setActionPlanId(collectionCase.getActionPlanId());
+    newCase.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
     newCase.setState(CaseState.valueOf(collectionCase.getState()));
     newCase.setTreatmentCode(collectionCase.getTreatmentCode());
     newCase.setAddressLine1(collectionCase.getAddress().getAddressLine1());
@@ -102,7 +103,13 @@ public class EventReceiverTest {
     newCase.setLad(collectionCase.getLad());
     newCase.setHtcWillingness(collectionCase.getHtcWillingness());
     newCase.setHtcDigital(collectionCase.getHtcDigital());
-
+    newCase.setAddressLevel(collectionCase.getAddress().getAddressLevel());
+    newCase.setAbpCode(collectionCase.getAddress().getApbCode());
+    newCase.setAddressType(collectionCase.getAddress().getAddressType());
+    newCase.setUprn(collectionCase.getAddress().getUprn());
+    newCase.setEstabArid(collectionCase.getAddress().getEstabArid());
+    newCase.setEstabType(collectionCase.getAddress().getEstabType());
+    newCase.setOrganisationName(collectionCase.getAddress().getOrganisationName());
     return newCase;
   }
 }


### PR DESCRIPTION
## Motivation and Context
The case distribution messages were missing some case attributes, we need all attributes to be distributed and persisted in the action-scheduler cases table.

## What has Changed
- Include all current case attributes on case DTO
- Set all current case attributes when creating messages

## How to Test
Run acceptance tests against this branch and https://github.com/ONSdigital/census-rm-case-processor/pull/9. Check the cases table in action-scheduler persists all the case attributes from the sample file.

## Links
https://github.com/ONSdigital/census-rm-case-processor/pull/9
https://trello.com/c/KMYeO526/738-defect-action-scheduler-is-missing-some-case-attributes-5