### PR TITLE
Remove Docker image push from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ before_install:
 script: travis_wait mvn verify jacoco:report
 
 after_success:
-- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
-  docker push "eu.gcr.io/census-rm-ci/rm/census-rm-action-scheduler";
-  fi
 - bash <(curl -s https://codecov.io/bash)
 
 cache:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We are building and pushing our Docker images using Concourse instead of Travis. We need to stop Travis from pushing images, which are triggering extra deployments in Concourse which are not needed or wanted.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Removed the Docker image push from the Travis settings.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Merge to master. Travis shouldn't push to GCR.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
Trello: https://trello.com/c/4chYCOrj

# Screenshots (if appropriate):