### PR TITLE
Break action rules into individual transactions

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/ActionInstructionBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/ActionInstructionBuilder.java
@@ -5,6 +5,9 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.census.action.model.UacQidTuple;
+import uk.gov.ons.census.action.model.dto.instruction.field.ActionAddress;
+import uk.gov.ons.census.action.model.dto.instruction.field.ActionInstruction;
+import uk.gov.ons.census.action.model.dto.instruction.field.ActionRequest;
 import uk.gov.ons.census.action.model.entity.ActionRule;
 import uk.gov.ons.census.action.model.entity.Case;
 
@@ -19,12 +22,12 @@ public class ActionInstructionBuilder {
     this.qidUacBuilder = qidUacBuilder;
   }
 
-  public uk.gov.ons.census.action.model.dto.instruction.field.ActionInstruction
+  public ActionInstruction
       buildFieldActionInstruction(Case caze, ActionRule actionRule) {
 
     UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(caze);
 
-    uk.gov.ons.census.action.model.dto.instruction.field.ActionAddress actionAddress =
+    ActionAddress actionAddress =
         new uk.gov.ons.census.action.model.dto.instruction.field.ActionAddress();
     actionAddress.setLine1(caze.getAddressLine1());
     actionAddress.setLine2(caze.getAddressLine2());
@@ -42,7 +45,7 @@ public class ActionInstructionBuilder {
       actionAddress.setLongitude(new BigDecimal(caze.getLongitude()));
     }
 
-    uk.gov.ons.census.action.model.dto.instruction.field.ActionRequest actionRequest =
+    ActionRequest actionRequest =
         new uk.gov.ons.census.action.model.dto.instruction.field.ActionRequest();
     actionRequest.setActionId(UUID.randomUUID().toString());
     actionRequest.setResponseRequired(false);
@@ -63,7 +66,7 @@ public class ActionInstructionBuilder {
     }
     // TODO undeliveredAsAddress, blankQreReturned, ccsQuestionnaireUrl, ceDeliveryReqd,
     // ceCE1Complete, ceActualResponses
-    uk.gov.ons.census.action.model.dto.instruction.field.ActionInstruction actionInstruction =
+    ActionInstruction actionInstruction =
         new uk.gov.ons.census.action.model.dto.instruction.field.ActionInstruction();
     actionInstruction.setActionRequest(actionRequest);
 

--- a/src/main/java/uk/gov/ons/census/action/builders/ActionInstructionBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/ActionInstructionBuilder.java
@@ -22,8 +22,7 @@ public class ActionInstructionBuilder {
     this.qidUacBuilder = qidUacBuilder;
   }
 
-  public ActionInstruction
-      buildFieldActionInstruction(Case caze, ActionRule actionRule) {
+  public ActionInstruction buildFieldActionInstruction(Case caze, ActionRule actionRule) {
 
     UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(caze);
 

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleScheduler.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleScheduler.java
@@ -8,16 +8,16 @@ import org.springframework.stereotype.Service;
 @Service
 public class ActionRuleScheduler {
   private static final Logger log = LoggerFactory.getLogger(ActionRuleScheduler.class);
-  private final ActionRuleProcessor actionRuleProcessor;
+  private final ActionRuleTriggerer actionRuleTriggerer;
 
-  public ActionRuleScheduler(ActionRuleProcessor actionRuleProcessor) {
-    this.actionRuleProcessor = actionRuleProcessor;
+  public ActionRuleScheduler(ActionRuleTriggerer actionRuleTriggerer) {
+    this.actionRuleTriggerer = actionRuleTriggerer;
   }
 
   @Scheduled(fixedDelayString = "${scheduler.frequency}")
-  public void processActionRules() {
+  public void triggerActionRules() {
     try {
-      actionRuleProcessor.processActionRules();
+      actionRuleTriggerer.triggerActionRules();
     } catch (Exception e) {
       log.error("Unexpected exception while processing Action Rules", e);
     }

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleTriggerer.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleTriggerer.java
@@ -1,0 +1,31 @@
+package uk.gov.ons.census.action.schedule;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.action.model.entity.ActionRule;
+import uk.gov.ons.census.action.model.repository.ActionRuleRepository;
+
+@Component
+public class ActionRuleTriggerer {
+  private final ActionRuleRepository actionRuleRepo;
+  private final ActionRuleProcessor actionRuleProcessor;
+
+  public ActionRuleTriggerer(ActionRuleRepository actionRuleRepo,
+      ActionRuleProcessor actionRuleProcessor) {
+    this.actionRuleRepo = actionRuleRepo;
+    this.actionRuleProcessor = actionRuleProcessor;
+  }
+
+  @Transactional
+  public void triggerActionRules() {
+    List<ActionRule> triggeredActionRules =
+        actionRuleRepo.findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(OffsetDateTime.now());
+
+    for (ActionRule triggeredActionRule : triggeredActionRules) {
+      actionRuleProcessor.createScheduledActions(triggeredActionRule);
+    }
+  }
+
+}

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleTriggerer.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleTriggerer.java
@@ -12,8 +12,8 @@ public class ActionRuleTriggerer {
   private final ActionRuleRepository actionRuleRepo;
   private final ActionRuleProcessor actionRuleProcessor;
 
-  public ActionRuleTriggerer(ActionRuleRepository actionRuleRepo,
-      ActionRuleProcessor actionRuleProcessor) {
+  public ActionRuleTriggerer(
+      ActionRuleRepository actionRuleRepo, ActionRuleProcessor actionRuleProcessor) {
     this.actionRuleRepo = actionRuleRepo;
     this.actionRuleProcessor = actionRuleProcessor;
   }
@@ -27,5 +27,4 @@ public class ActionRuleTriggerer {
       actionRuleProcessor.createScheduledActions(triggeredActionRule);
     }
   }
-
 }

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
@@ -59,12 +59,6 @@ public class ActionRuleProcessorTest {
 
     List<Case> cases = getRandomCases(expectedCaseCount);
 
-    // For some reason this works and the 'normal' when.thenReturn way doesn't, might be the JPA
-    // OneToMany
-    doReturn(Arrays.asList(actionRule))
-        .when(actionRuleRepo)
-        .findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(any());
-
     when(printFileDtoBuilder.buildPrintFileDto(
             any(Case.class), any(String.class), any(UUID.class), anyString()))
         .thenReturn(new PrintFileDto());
@@ -85,7 +79,7 @@ public class ActionRuleProcessorTest {
             customCaseRepository,
             null);
     ReflectionTestUtils.setField(actionRuleProcessor, "outboundExchange", OUTBOUND_EXCHANGE);
-    actionRuleProcessor.processActionRules();
+    actionRuleProcessor.createScheduledActions(actionRule);
 
     // then
     ArgumentCaptor<ActionRule> actionRuleCaptor = ArgumentCaptor.forClass(ActionRule.class);
@@ -108,10 +102,6 @@ public class ActionRuleProcessorTest {
 
     when(customCaseRepository.streamAll(any(Specification.class))).thenReturn(cases.stream());
 
-    doReturn(Arrays.asList(actionRule))
-        .when(actionRuleRepo)
-        .findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(any());
-
     when(actionInstructionBuilder.buildFieldActionInstruction(any(Case.class), eq(actionRule)))
         .thenReturn(new uk.gov.ons.census.action.model.dto.instruction.field.ActionInstruction());
 
@@ -130,7 +120,7 @@ public class ActionRuleProcessorTest {
 
     // when
     ReflectionTestUtils.setField(actionRuleProcessor, "outboundExchange", OUTBOUND_EXCHANGE);
-    actionRuleProcessor.processActionRules();
+    actionRuleProcessor.createScheduledActions(actionRule);
 
     // then
     verify(actionInstructionBuilder, times(expectedCaseCount))
@@ -156,10 +146,6 @@ public class ActionRuleProcessorTest {
     // when
     when(customCaseRepository.streamAll(any(Specification.class))).thenReturn(cases.stream());
 
-    doReturn(Arrays.asList(actionRule))
-        .when(actionRuleRepo)
-        .findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(any());
-
     when(printCaseSelectedBuilder.buildMessage(any(PrintFileDto.class), any(UUID.class)))
         .thenReturn(new ResponseManagementEvent());
 
@@ -180,7 +166,7 @@ public class ActionRuleProcessorTest {
     ReflectionTestUtils.setField(actionRuleProcessor, "outboundExchange", OUTBOUND_EXCHANGE);
     RuntimeException actualException = null;
     try {
-      actionRuleProcessor.processActionRules();
+      actionRuleProcessor.createScheduledActions(actionRule);
     } catch (RuntimeException runtimeException) {
       actualException = runtimeException;
     }
@@ -207,10 +193,6 @@ public class ActionRuleProcessorTest {
     // when
     when(customCaseRepository.streamAll(any(Specification.class))).thenReturn(cases.stream());
 
-    doReturn(Arrays.asList(actionRule))
-        .when(actionRuleRepo)
-        .findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(any());
-
     when(printFileDtoBuilder.buildPrintFileDto(
             any(Case.class), any(String.class), any(UUID.class), anyString()))
         .thenReturn(new PrintFileDto());
@@ -234,7 +216,7 @@ public class ActionRuleProcessorTest {
             customCaseRepository,
             null);
     ReflectionTestUtils.setField(actionRuleProcessor, "outboundExchange", OUTBOUND_EXCHANGE);
-    actionRuleProcessor.processActionRules();
+    actionRuleProcessor.createScheduledActions(actionRule);
 
     // then
     // exception thrown

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleTriggererTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleTriggererTest.java
@@ -1,0 +1,56 @@
+package uk.gov.ons.census.action.schedule;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import uk.gov.ons.census.action.model.entity.ActionRule;
+import uk.gov.ons.census.action.model.repository.ActionRuleRepository;
+
+public class ActionRuleTriggererTest {
+  private final ActionRuleRepository actionRuleRepo = mock(ActionRuleRepository.class);
+  private final ActionRuleProcessor actionRuleProcessor = mock(ActionRuleProcessor.class);
+
+  @Test
+  public void testTriggerActionRules() {
+    // Given
+    ActionRule actionRule = new ActionRule();
+    when(actionRuleRepo.findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(
+        any(OffsetDateTime.class))).thenReturn(Collections.singletonList(actionRule));
+
+    // When
+    ActionRuleTriggerer underTest = new ActionRuleTriggerer(actionRuleRepo, actionRuleProcessor);
+    underTest.triggerActionRules();
+
+    // Then
+    verify(actionRuleProcessor).createScheduledActions(eq(actionRule));
+  }
+
+  @Test
+  public void testTriggerMultipleActionRules() {
+    // Given
+    List<ActionRule> actionRules = new ArrayList<>(50);
+    for (int i=0; i < 50; i++) {
+      actionRules.add(new ActionRule());
+    }
+
+    when(actionRuleRepo.findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(
+        any(OffsetDateTime.class))).thenReturn(actionRules);
+
+    // When
+    ActionRuleTriggerer underTest = new ActionRuleTriggerer(actionRuleRepo, actionRuleProcessor);
+    underTest.triggerActionRules();
+
+    // Then
+    verify(actionRuleProcessor, times(50)).createScheduledActions(
+        any(ActionRule.class));
+  }
+}

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleTriggererTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleTriggererTest.java
@@ -24,7 +24,8 @@ public class ActionRuleTriggererTest {
     // Given
     ActionRule actionRule = new ActionRule();
     when(actionRuleRepo.findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(
-        any(OffsetDateTime.class))).thenReturn(Collections.singletonList(actionRule));
+            any(OffsetDateTime.class)))
+        .thenReturn(Collections.singletonList(actionRule));
 
     // When
     ActionRuleTriggerer underTest = new ActionRuleTriggerer(actionRuleRepo, actionRuleProcessor);
@@ -38,19 +39,19 @@ public class ActionRuleTriggererTest {
   public void testTriggerMultipleActionRules() {
     // Given
     List<ActionRule> actionRules = new ArrayList<>(50);
-    for (int i=0; i < 50; i++) {
+    for (int i = 0; i < 50; i++) {
       actionRules.add(new ActionRule());
     }
 
     when(actionRuleRepo.findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(
-        any(OffsetDateTime.class))).thenReturn(actionRules);
+            any(OffsetDateTime.class)))
+        .thenReturn(actionRules);
 
     // When
     ActionRuleTriggerer underTest = new ActionRuleTriggerer(actionRuleRepo, actionRuleProcessor);
     underTest.triggerActionRules();
 
     // Then
-    verify(actionRuleProcessor, times(50)).createScheduledActions(
-        any(ActionRule.class));
+    verify(actionRuleProcessor, times(50)).createScheduledActions(any(ActionRule.class));
   }
 }


### PR DESCRIPTION
# Motivation and Context
Action Rules that were scheduled for exactly the same time would execute within a single transaction. Potentially that meant that we could be running a huge transaction for initial contact and other key events. By breaking each action rule execution into its own transaction, we reduce the memory footprint and the risk of rolling back useful work that has been done.

# What has changed
Added in an `ActionRuleTriggerer` class to allow the transaction boundaries to be delineated.

# How to test?
Run the acceptance tests - the change should cause no regression.

# Links
Trello: https://trello.com/c/5m9nDL4p