### PR TITLE
Defect #969: QM Print File - coordinator_id

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -42,6 +42,7 @@ public class PrintFileDtoBuilder {
     printFileDto.setBatchId(batchUUID.toString());
     printFileDto.setPackCode(packCode);
     printFileDto.setActionType(actionType);
+    printFileDto.setFieldCoordinatorId(caze.getFieldCoordinatorId());
 
     return printFileDto;
   }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/PrintFileDto.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/PrintFileDto.java
@@ -21,4 +21,5 @@ public class PrintFileDto {
   private int batchQuantity;
   private String packCode;
   private String actionType;
+  private String fieldCoordinatorId;
 }

--- a/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
@@ -98,6 +98,7 @@ public class PrintFileDtoBuilderTest {
     printFileDto.setBatchId(BATCH_UUID.toString());
     printFileDto.setPackCode(actionTypeToPackCodeMap.get(expectedActionType));
     printFileDto.setActionType("test_actiontype");
+    printFileDto.setFieldCoordinatorId(caze.getFieldCoordinatorId());
 
     return printFileDto;
   }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
During WhiteLodge testing it was found the Questionnaire Management print files (E, W and NI) are currently holding the 'caseref' in the column that should contain 'coordinator_id'. 

coordinator_id is provided on the sample file, can range from 8 to 10 characters and is NOT mandatory

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

- Added `fieldCoordinatorId` to the outbound print message DTO

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

- Some Java magic probably
- `mvn clean install`
- Run against acceptance tests of the same branch name (fix-defect-969)

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
- https://github.com/ONSdigital/census-rm-acceptance-tests/pull/88
- https://github.com/ONSdigital/census-rm-print-file-service/pull/5
- [Trello card #969](https://trello.com/c/DxUlMxSc)
