### PR TITLE
Ignore fulfilment codes which action scheduler doesn't need to process

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/messaging/ActionFulfilmentReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/ActionFulfilmentReceiver.java
@@ -50,16 +50,11 @@ public class ActionFulfilmentReceiver {
       throw new RuntimeException(
           String.format("Cannot find case %s for fulfilment request.", caseId));
     }
-    String packCode =
+    String fulfilmentCode =
         responseManagementEvent.getPayload().getFulfilmentRequest().getFulfilmentCode();
-    Optional<Integer> questionnaireType = determineQuestionnaireType(packCode);
+    Optional<Integer> questionnaireType = determineQuestionnaireType(fulfilmentCode);
     if (questionnaireType.isEmpty()) {
-      log.with("caseId", caseId)
-          .with("PackCode", packCode)
-          .error("Unknown packCode in fulfilment request.");
-      throw new RuntimeException(
-          String.format(
-              "Unknown packCode %s in fulfilment request for caseId %s", packCode, caseId));
+      return;
     }
     UacQidDTO uacQid = caseClient.getUacQid(caseId, questionnaireType.get().toString());
     PrintFileDto printFile =

--- a/src/main/java/uk/gov/ons/census/action/messaging/ActionFulfilmentReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/ActionFulfilmentReceiver.java
@@ -54,7 +54,20 @@ public class ActionFulfilmentReceiver {
         responseManagementEvent.getPayload().getFulfilmentRequest().getFulfilmentCode();
     Optional<Integer> questionnaireType = determineQuestionnaireType(fulfilmentCode);
     if (questionnaireType.isEmpty()) {
-      return;
+      switch (fulfilmentCode) {
+        case "UACHHT1":
+        case "UACHHT2":
+        case "UACHHT2W":
+        case "UACHHT4":
+        case "UACIT1":
+        case "UACIT2":
+        case "UACIT2W":
+        case "UACIT4":
+          return; // Ignore SMS fulfilments
+        default:
+          log.with("fulfilment_code", fulfilmentCode).warn("Unexpected fulfilment code received");
+          return;
+      }
     }
     UacQidDTO uacQid = caseClient.getUacQid(caseId, questionnaireType.get().toString());
     PrintFileDto printFile =

--- a/src/test/java/uk.gov.ons.census.action/messaging/ActionFulfilmentReceiverTest.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/ActionFulfilmentReceiverTest.java
@@ -2,8 +2,6 @@ package uk.gov.ons.census.action.messaging;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyObject;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,7 +29,8 @@ public class ActionFulfilmentReceiverTest {
 
     when(caseRepository.findByCaseId(any(UUID.class))).thenReturn(Optional.of(caze));
 
-    ActionFulfilmentReceiver underTest = new ActionFulfilmentReceiver(rabbitTemplate, caseClient, caseRepository);
+    ActionFulfilmentReceiver underTest =
+        new ActionFulfilmentReceiver(rabbitTemplate, caseClient, caseRepository);
 
     ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
     event.getPayload().getFulfilmentRequest().setCaseId(UUID.randomUUID().toString());
@@ -50,7 +49,8 @@ public class ActionFulfilmentReceiverTest {
 
     when(caseRepository.findByCaseId(any(UUID.class))).thenReturn(Optional.of(caze));
 
-    ActionFulfilmentReceiver underTest = new ActionFulfilmentReceiver(rabbitTemplate, caseClient, caseRepository);
+    ActionFulfilmentReceiver underTest =
+        new ActionFulfilmentReceiver(rabbitTemplate, caseClient, caseRepository);
 
     ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
     event.getPayload().getFulfilmentRequest().setFulfilmentCode("UACHHT1");

--- a/src/test/java/uk.gov.ons.census.action/messaging/ActionFulfilmentReceiverTest.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/ActionFulfilmentReceiverTest.java
@@ -1,0 +1,60 @@
+package uk.gov.ons.census.action.messaging;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.jeasy.random.EasyRandom;
+import org.junit.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import uk.gov.ons.census.action.client.CaseClient;
+import uk.gov.ons.census.action.model.dto.ResponseManagementEvent;
+import uk.gov.ons.census.action.model.entity.Case;
+import uk.gov.ons.census.action.model.repository.CaseRepository;
+
+public class ActionFulfilmentReceiverTest {
+
+  @Test
+  public void testReceiveEventIgnoresUnexpectedFulfilmentCode() {
+    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
+    CaseClient caseClient = mock(CaseClient.class);
+    CaseRepository caseRepository = mock(CaseRepository.class);
+
+    EasyRandom easyRandom = new EasyRandom();
+
+    Case caze = easyRandom.nextObject(Case.class);
+
+    when(caseRepository.findByCaseId(any(UUID.class))).thenReturn(Optional.of(caze));
+
+    ActionFulfilmentReceiver underTest = new ActionFulfilmentReceiver(rabbitTemplate, caseClient, caseRepository);
+
+    ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
+    event.getPayload().getFulfilmentRequest().setCaseId(UUID.randomUUID().toString());
+    underTest.receiveEvent(event);
+  }
+
+  @Test
+  public void testReceiveEventIgnoresUACFulfilmentCode() {
+    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
+    CaseClient caseClient = mock(CaseClient.class);
+    CaseRepository caseRepository = mock(CaseRepository.class);
+
+    EasyRandom easyRandom = new EasyRandom();
+
+    Case caze = easyRandom.nextObject(Case.class);
+
+    when(caseRepository.findByCaseId(any(UUID.class))).thenReturn(Optional.of(caze));
+
+    ActionFulfilmentReceiver underTest = new ActionFulfilmentReceiver(rabbitTemplate, caseClient, caseRepository);
+
+    ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
+    event.getPayload().getFulfilmentRequest().setFulfilmentCode("UACHHT1");
+    event.getPayload().getFulfilmentRequest().setCaseId(UUID.randomUUID().toString());
+    underTest.receiveEvent(event);
+  }
+}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Certain fulfilment codes don't get printed so action scheduler can ignore them.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Action scheduler now ignores fulfilment codes aren't print specific.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run acceptance tests using branch of the same name and make sure UAC fulfilment codes don't cause action scheduler to error.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/yX4y7G8z/944-rmc-145b-implement-uac-fulfilment-event-part-a-13-part-b-5

# Screenshots (if appropriate):