### PR TITLE
RMC-138 Scheduled Reminder Letters

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -29,12 +29,6 @@ public class PrintFileDtoBuilder {
     }
 
     printFileDto.setCaseRef(selectedCase.getCaseRef());
-
-    //    // TODO: Don't believe we have these at the moment
-    //    printFileDto.setTitle("");
-    //    printFileDto.setForename("");
-    //    printFileDto.setSurname("");
-
     printFileDto.setAddressLine1(selectedCase.getAddressLine1());
     printFileDto.setAddressLine2(selectedCase.getAddressLine2());
     printFileDto.setAddressLine3(selectedCase.getAddressLine3());

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -15,8 +15,9 @@ public class PrintFileDtoBuilder {
   }
 
   public PrintFileDto buildPrintFileDto(
-      Case caze, String packCode, UUID batchUUID, String actionType) {
-    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(caze);
+      Case selectedCase, String packCode, UUID batchUUID, String actionType) {
+
+    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(selectedCase, packCode);
 
     PrintFileDto printFileDto = new PrintFileDto();
     printFileDto.setUac(uacQidTuple.getUacQidLink().getUac());
@@ -27,22 +28,22 @@ public class PrintFileDtoBuilder {
       printFileDto.setQidWales(uacQidTuple.getUacQidLinkWales().get().getQid());
     }
 
-    printFileDto.setCaseRef(caze.getCaseRef());
+    printFileDto.setCaseRef(selectedCase.getCaseRef());
 
-    // TODO: Don't believe we have these at the moment
-    printFileDto.setTitle("");
-    printFileDto.setForename("");
-    printFileDto.setSurname("");
+    //    // TODO: Don't believe we have these at the moment
+    //    printFileDto.setTitle("");
+    //    printFileDto.setForename("");
+    //    printFileDto.setSurname("");
 
-    printFileDto.setAddressLine1(caze.getAddressLine1());
-    printFileDto.setAddressLine2(caze.getAddressLine2());
-    printFileDto.setAddressLine3(caze.getAddressLine3());
-    printFileDto.setTownName(caze.getTownName());
-    printFileDto.setPostcode(caze.getPostcode());
+    printFileDto.setAddressLine1(selectedCase.getAddressLine1());
+    printFileDto.setAddressLine2(selectedCase.getAddressLine2());
+    printFileDto.setAddressLine3(selectedCase.getAddressLine3());
+    printFileDto.setTownName(selectedCase.getTownName());
+    printFileDto.setPostcode(selectedCase.getPostcode());
     printFileDto.setBatchId(batchUUID.toString());
     printFileDto.setPackCode(packCode);
     printFileDto.setActionType(actionType);
-    printFileDto.setFieldCoordinatorId(caze.getFieldCoordinatorId());
+    printFileDto.setFieldCoordinatorId(selectedCase.getFieldCoordinatorId());
 
     return printFileDto;
   }

--- a/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.ons.census.action.client.CaseClient;
 import uk.gov.ons.census.action.model.UacQidTuple;
 import uk.gov.ons.census.action.model.dto.UacQidDTO;
+import uk.gov.ons.census.action.model.entity.ActionType;
 import uk.gov.ons.census.action.model.entity.Case;
 import uk.gov.ons.census.action.model.entity.UacQidLink;
 import uk.gov.ons.census.action.model.repository.UacQidLinkRepository;
@@ -19,13 +20,13 @@ public class QidUacBuilder {
 
   private static final Set<String> packCodesRequiringNewUacQidPair =
       Set.of(
-          "P_RL_1RL1_1",
-          "P_RL_1RL2B_1",
-          "P_RL_1RL4",
-          "P_RL_1RL1_2",
-          "P_RL_1RL2B_2",
-          "P_RL_2RL1_3a",
-          "P_RL_2RL2B_3a");
+          ActionType.P_RL_1RL1_1.name(),
+          ActionType.P_RL_1RL2B_1.name(),
+          ActionType.P_RL_1RL4.name(),
+          ActionType.P_RL_1RL1_2.name(),
+          ActionType.P_RL_1RL2B_2.name(),
+          ActionType.P_RL_2RL1_3a.name(),
+          ActionType.P_RL_2RL2B_3a.name());
   private static final int NUM_OF_UAC_IAC_PAIRS_NEEDED_BY_A_WALES_INITIAL_CONTACT_QUESTIONNAIRE = 2;
   private static final int NUM_OF_UAC_IAC_PAIRS_NEEDED_FOR_SINGLE_LANGUAGE = 1;
   private static final String WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE = "02";

--- a/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
@@ -1,36 +1,63 @@
 package uk.gov.ons.census.action.builders;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
+import uk.gov.ons.census.action.client.CaseClient;
 import uk.gov.ons.census.action.model.UacQidTuple;
+import uk.gov.ons.census.action.model.dto.UacQidDTO;
 import uk.gov.ons.census.action.model.entity.Case;
 import uk.gov.ons.census.action.model.entity.UacQidLink;
 import uk.gov.ons.census.action.model.repository.UacQidLinkRepository;
 
 @Component
 public class QidUacBuilder {
+  private static final Logger log = LoggerFactory.getLogger(QidUacBuilder.class);
+
+  private static final Set<String> packCodesRequiringNewUacQidPair =
+      Set.of(
+          "P_RL_1RL1_1",
+          "P_RL_1RL2B_1",
+          "P_RL_1RL4",
+          "P_RL_1RL1_2",
+          "P_RL_1RL2B_2",
+          "P_RL_2RL1_3a",
+          "P_RL_2RL2B_3a");
   private static final int NUM_OF_UAC_IAC_PAIRS_NEEDED_BY_A_WALES_INITIAL_CONTACT_QUESTIONNAIRE = 2;
   private static final int NUM_OF_UAC_IAC_PAIRS_NEEDED_FOR_SINGLE_LANGUAGE = 1;
   private static final String WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE = "02";
   private static final String WALES_IN_WELSH_QUESTIONNAIRE_TYPE = "03";
-  public static final String HOUSEHLD_INITIAL_CONTACT_QUESTIONNIARE_TREATMENT_CODE_PREFIX = "HH_Q";
+  private static final String UNKNOWN_COUNTRY_ERROR = "Unknown Country";
+  private static final String UNEXPECTED_CASE_TYPE_ERROR = "Unexpected Case Type";
+  public static final String HOUSEHOLD_INITIAL_CONTACT_QUESTIONNAIRE_TREATMENT_CODE_PREFIX = "HH_Q";
   public static final String WALES_TREATMENT_CODE_SUFFIX = "W";
 
   private final UacQidLinkRepository uacQidLinkRepository;
+  private final CaseClient caseClient;
 
-  public QidUacBuilder(UacQidLinkRepository uacQidLinkRepository) {
+  public QidUacBuilder(UacQidLinkRepository uacQidLinkRepository, CaseClient caseClient) {
     this.uacQidLinkRepository = uacQidLinkRepository;
+    this.caseClient = caseClient;
   }
 
-  public UacQidTuple getUacQidLinks(Case caze) {
-    List<UacQidLink> uacQidLinks = uacQidLinkRepository.findByCaseId(caze.getCaseId().toString());
+  public UacQidTuple getUacQidLinks(Case linkedCase, String packCode) {
     UacQidTuple uacQidTuple = new UacQidTuple();
+
+    if (packCodeRequiresNewUacQidPair(packCode)) {
+      uacQidTuple.setUacQidLink(createNewUacQidPair(linkedCase));
+      return uacQidTuple;
+    }
+
+    List<UacQidLink> uacQidLinks =
+        uacQidLinkRepository.findByCaseId(linkedCase.getCaseId().toString());
 
     if (uacQidLinks == null || uacQidLinks.isEmpty()) {
       throw new RuntimeException(); // TODO: How can we process this case without a UAC?
     } else if (uacQidLinks.size() > NUM_OF_UAC_IAC_PAIRS_NEEDED_FOR_SINGLE_LANGUAGE) {
-      if (isQuestionnaireWelsh(caze.getTreatmentCode())
+      if (isQuestionnaireWelsh(linkedCase.getTreatmentCode())
           && uacQidLinks.size()
               == NUM_OF_UAC_IAC_PAIRS_NEEDED_BY_A_WALES_INITIAL_CONTACT_QUESTIONNAIRE) {
         uacQidTuple.setUacQidLink(
@@ -47,7 +74,7 @@ public class QidUacBuilder {
       } else {
         throw new RuntimeException(); // TODO: How do we know which one to use?
       }
-    } else if (!isQuestionnaireWelsh(caze.getTreatmentCode())) {
+    } else if (!isQuestionnaireWelsh(linkedCase.getTreatmentCode())) {
       // Implicitly from the logic above, there can only be one UAC/QID pair - the right one
       uacQidTuple.setUacQidLink(uacQidLinks.get(0));
     } else {
@@ -58,8 +85,21 @@ public class QidUacBuilder {
     return uacQidTuple;
   }
 
+  private UacQidLink createNewUacQidPair(Case linkedCase) {
+    int questionnaireType = calculateQuestionnaireType(linkedCase.getTreatmentCode());
+    UacQidDTO newUacQidPair =
+        caseClient.getUacQid(linkedCase.getCaseId(), Integer.toString(questionnaireType));
+    UacQidLink newUacQidLink = new UacQidLink();
+    newUacQidLink.setCaseId(linkedCase.getCaseId().toString());
+    newUacQidLink.setQid(newUacQidPair.getQid());
+    newUacQidLink.setUac(newUacQidPair.getUac());
+    // Don't persist the new UAC QID link here, that is handled by our eventual consistency model in
+    // the API request
+    return newUacQidLink;
+  }
+
   private boolean isQuestionnaireWelsh(String treatmentCode) {
-    return (treatmentCode.startsWith(HOUSEHLD_INITIAL_CONTACT_QUESTIONNIARE_TREATMENT_CODE_PREFIX)
+    return (treatmentCode.startsWith(HOUSEHOLD_INITIAL_CONTACT_QUESTIONNAIRE_TREATMENT_CODE_PREFIX)
         && treatmentCode.endsWith(WALES_TREATMENT_CODE_SUFFIX));
   }
 
@@ -77,5 +117,51 @@ public class QidUacBuilder {
     }
 
     throw new RuntimeException(); // We can't find the one we wanted
+  }
+
+  private boolean packCodeRequiresNewUacQidPair(String packCode) {
+    return packCodesRequiringNewUacQidPair.contains(packCode);
+  }
+
+  public static int calculateQuestionnaireType(String treatmentCode) {
+    String country = treatmentCode.substring(treatmentCode.length() - 1);
+    if (!country.equals("E") && !country.equals("W") && !country.equals("N")) {
+      log.with("treatment_code", treatmentCode).error(UNKNOWN_COUNTRY_ERROR);
+      throw new IllegalArgumentException();
+    }
+
+    if (treatmentCode.startsWith("HH")) {
+      switch (country) {
+        case "E":
+          return 1;
+        case "W":
+          return 2;
+        case "N":
+          return 4;
+      }
+    } else if (treatmentCode.startsWith("CI")) {
+      switch (country) {
+        case "E":
+          return 21;
+        case "W":
+          return 22;
+        case "N":
+          return 24;
+      }
+    } else if (treatmentCode.startsWith("CE")) {
+      switch (country) {
+        case "E":
+          return 31;
+        case "W":
+          return 32;
+        case "N":
+          return 34;
+      }
+    } else {
+      log.with("treatment_code", treatmentCode).error(UNEXPECTED_CASE_TYPE_ERROR);
+      throw new IllegalArgumentException();
+    }
+
+    throw new RuntimeException(); // This code should be unreachable
   }
 }

--- a/src/main/java/uk/gov/ons/census/action/model/UacQidTuple.java
+++ b/src/main/java/uk/gov/ons/census/action/model/UacQidTuple.java
@@ -7,5 +7,5 @@ import uk.gov.ons.census.action.model.entity.UacQidLink;
 @Data
 public class UacQidTuple {
   private UacQidLink uacQidLink;
-  private Optional<UacQidLink> uacQidLinkWales = Optional.ofNullable(null);
+  private Optional<UacQidLink> uacQidLinkWales = Optional.empty();
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -1,16 +1,34 @@
 package uk.gov.ons.census.action.model.entity;
 
 public enum ActionType {
+
+  // Initial contact letters
   ICL1E(ActionHandler.PRINTER), // Census initial contact letter for England
   ICL2W(ActionHandler.PRINTER), // Census initial contact letter for Wales
   ICL4N(ActionHandler.PRINTER), // Census initial contact letter for NI
 
+  // Initial contact questionnaires
   ICHHQE(ActionHandler.PRINTER), // Census household questionnaire for England
   ICHHQW(ActionHandler.PRINTER), // Census household questionnaire for Wales
   ICHHQN(ActionHandler.PRINTER), // Census household questionnaire for NI
 
+  // Fieldwork reminders
   FF2QE(ActionHandler.FIELD), // Fieldwork follow up F2 questionnaire for England
 
+  // Reminder letters
+  P_RL_1RL1_1(ActionHandler.PRINTER), // 1st Reminder, Letter - for England addresses
+  P_RL_1RL2B_1(
+      ActionHandler
+          .PRINTER), // 1st Reminder, Letter - for Wales addresses (bilingual Welsh and English)
+  P_RL_1RL4(ActionHandler.PRINTER), // 1st Reminder, Letter - for Ireland addresses
+  P_RL_1RL1_2(ActionHandler.PRINTER), // 2nd Reminder, Letter - for England addresses
+  P_RL_1RL2B_2(
+      ActionHandler
+          .PRINTER), // 2nd Reminder, Letter - for Wales addresses (bilingual Welsh and English)
+  P_RL_2RL1_3a(ActionHandler.PRINTER), // 3rd Reminder, Letter - for England addresses
+  P_RL_2RL2B_3a(ActionHandler.PRINTER), // 3rd Reminder, Letter - for Wales addresses
+
+  // Ad hoc fulfilment requests
   P_OR_HX(ActionHandler.PRINTER), // Household questionnaires
   P_LP_HLX(ActionHandler.PRINTER), // Household questionnaires large print
   P_TB_TBX(ActionHandler.PRINTER); // Household translation booklets

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
@@ -145,8 +145,8 @@ public class ActionRuleProcessor {
           batchLog.info(
               "Sending in progress, sent {} printer action messages so far", messagesSent - 1);
         }
-        batchLog.info("Finished sending, sent {} printer action messages", messagesSent);
       }
+      batchLog.info("Finished sending, sent {} printer action messages", messagesSent);
     } catch (InterruptedException | ExecutionException e) {
       throw new RuntimeException(e); // Roll the whole transaction back
     }
@@ -165,15 +165,16 @@ public class ActionRuleProcessor {
       List<Future<FieldworkFollowup>> results =
           EXECUTOR_SERVICE.invokeAll(fieldworkFollowupBuilders);
 
-      log.info("About to send {} FieldworkFollowup messages", results.size());
+      log.info("About to send {} field action messages", results.size());
       int messagesSent = 0;
       for (Future<FieldworkFollowup> result : results) {
-        if (messagesSent++ % 1000 == 0) {
-          log.info("Sent {} FieldworkFollowup messages", messagesSent - 1);
-        }
 
         rabbitTemplate.convertAndSend(outboundExchange, routingKey, result.get());
+        if (messagesSent++ % 1000 == 0) {
+          log.info("Finished sending, sent {} field action messages", messagesSent - 1);
+        }
       }
+      log.info("Finished sending, sent {} field action messages", messagesSent);
     } catch (InterruptedException | ExecutionException e) {
       throw new RuntimeException(e); // Roll the whole transaction back
     }

--- a/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverIT.java
@@ -48,8 +48,7 @@ public class FulfilmentRequestReceiverIT {
   @Value("${queueconfig.outbound-printer-queue}")
   private String outboundPrinterQueue;
 
-  @Rule
-  public WireMockRule mockCaseApi = new WireMockRule(wireMockConfig().port(8089));
+  @Rule public WireMockRule mockCaseApi = new WireMockRule(wireMockConfig().port(8089));
 
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
 

--- a/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverIT.java
@@ -48,8 +48,12 @@ public class FulfilmentRequestReceiverIT {
   @Value("${queueconfig.outbound-printer-queue}")
   private String outboundPrinterQueue;
 
+  @Value("${caseapi.port}")
+  private int caseApiPort;
+
   @Rule
-  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8089).httpsPort(8443));
+  public WireMockRule mockCaseApi =
+      new WireMockRule(wireMockConfig().port(caseApiPort).httpsPort(8443));
 
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
 

--- a/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverIT.java
@@ -49,7 +49,7 @@ public class FulfilmentRequestReceiverIT {
   private String outboundPrinterQueue;
 
   @Rule
-  public WireMockRule mockCaseApi = new WireMockRule(wireMockConfig().port(8089).httpsPort(8443));
+  public WireMockRule mockCaseApi = new WireMockRule(wireMockConfig().port(8089));
 
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
 

--- a/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverIT.java
@@ -48,12 +48,8 @@ public class FulfilmentRequestReceiverIT {
   @Value("${queueconfig.outbound-printer-queue}")
   private String outboundPrinterQueue;
 
-  @Value("${caseapi.port}")
-  private int caseApiPort;
-
   @Rule
-  public WireMockRule mockCaseApi =
-      new WireMockRule(wireMockConfig().port(caseApiPort).httpsPort(8443));
+  public WireMockRule mockCaseApi = new WireMockRule(wireMockConfig().port(8089).httpsPort(8443));
 
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
 

--- a/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
@@ -2,6 +2,7 @@ package uk.gov.ons.census.action.builders;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,16 +24,17 @@ public class PrintFileDtoBuilderTest {
   private static final String WELSH_QID = "WELSH_QID";
   private static final UUID BATCH_UUID = UUID.randomUUID();
   private static final ActionType expectedActionType = ActionType.ICL1E;
+  private static final String P_IC_ICL1 = "P_IC_ICL1";
 
-  private final HashMap<String, String> actionTypeToPackCodeMap =
+  private final HashMap<ActionType, String> actionTypeToPackCodeMap =
       new HashMap<>() {
         {
-          put("ICHHQE", "P_IC_H1");
-          put("ICHHQW", "P_IC_H2");
-          put("ICHHQN", "P_IC_H4");
-          put("ICL1E", "P_IC_ICL1");
-          put("ICL2W", "P_IC_ICL2B");
-          put("ICL4N", "P_IC_ICL4");
+          put(ActionType.ICHHQE, "P_IC_H1");
+          put(ActionType.ICHHQW, "P_IC_H2");
+          put(ActionType.ICHHQN, "P_IC_H4");
+          put(ActionType.ICL1E, "P_IC_ICL1");
+          put(ActionType.ICL2W, "P_IC_ICL2B");
+          put(ActionType.ICL4N, "P_IC_ICL4");
         }
       };
 
@@ -71,7 +73,7 @@ public class PrintFileDtoBuilderTest {
     uacQidTuple.setUacQidLinkWales(Optional.of(welshLink));
 
     QidUacBuilder qidUacBuilder = mock(QidUacBuilder.class);
-    when(qidUacBuilder.getUacQidLinks(any(Case.class))).thenReturn(uacQidTuple);
+    when(qidUacBuilder.getUacQidLinks(any(Case.class), eq(P_IC_ICL1))).thenReturn(uacQidTuple);
 
     return qidUacBuilder;
   }
@@ -85,10 +87,10 @@ public class PrintFileDtoBuilderTest {
 
     printFileDto.setCaseRef(caze.getCaseRef());
 
-    // TODO: where are these stored and used?
-    printFileDto.setTitle("");
-    printFileDto.setForename("");
-    printFileDto.setSurname("");
+    //    // TODO: where are these stored and used?
+    //    printFileDto.setTitle("");
+    //    printFileDto.setForename("");
+    //    printFileDto.setSurname("");
 
     printFileDto.setAddressLine1(caze.getAddressLine1());
     printFileDto.setAddressLine2(caze.getAddressLine2());

--- a/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
@@ -86,17 +86,12 @@ public class PrintFileDtoBuilderTest {
     printFileDto.setQidWales(WELSH_QID);
 
     printFileDto.setCaseRef(caze.getCaseRef());
-
-    //    // TODO: where are these stored and used?
-    //    printFileDto.setTitle("");
-    //    printFileDto.setForename("");
-    //    printFileDto.setSurname("");
-
     printFileDto.setAddressLine1(caze.getAddressLine1());
     printFileDto.setAddressLine2(caze.getAddressLine2());
     printFileDto.setAddressLine3(caze.getAddressLine3());
     printFileDto.setTownName(caze.getTownName());
     printFileDto.setPostcode(caze.getPostcode());
+
     printFileDto.setBatchId(BATCH_UUID.toString());
     printFileDto.setPackCode(actionTypeToPackCodeMap.get(expectedActionType));
     printFileDto.setActionType("test_actiontype");

--- a/src/test/java/uk/gov/ons/census/action/builders/QidUacBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/QidUacBuilderTest.java
@@ -1,10 +1,12 @@
 package uk.gov.ons.census.action.builders;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.ons.census.action.builders.QidUacBuilder.HOUSEHLD_INITIAL_CONTACT_QUESTIONNIARE_TREATMENT_CODE_PREFIX;
+import static uk.gov.ons.census.action.builders.QidUacBuilder.HOUSEHOLD_INITIAL_CONTACT_QUESTIONNAIRE_TREATMENT_CODE_PREFIX;
 import static uk.gov.ons.census.action.builders.QidUacBuilder.WALES_TREATMENT_CODE_SUFFIX;
 
 import java.util.ArrayList;
@@ -13,7 +15,9 @@ import java.util.LinkedList;
 import java.util.List;
 import org.jeasy.random.EasyRandom;
 import org.junit.Test;
+import uk.gov.ons.census.action.client.CaseClient;
 import uk.gov.ons.census.action.model.UacQidTuple;
+import uk.gov.ons.census.action.model.dto.UacQidDTO;
 import uk.gov.ons.census.action.model.entity.ActionPlan;
 import uk.gov.ons.census.action.model.entity.ActionRule;
 import uk.gov.ons.census.action.model.entity.ActionType;
@@ -22,12 +26,17 @@ import uk.gov.ons.census.action.model.entity.UacQidLink;
 import uk.gov.ons.census.action.model.repository.UacQidLinkRepository;
 
 public class QidUacBuilderTest {
-  UacQidLinkRepository uacQidLinkRepository = mock(UacQidLinkRepository.class);
+  private final UacQidLinkRepository uacQidLinkRepository = mock(UacQidLinkRepository.class);
+  private final CaseClient caseClient = mock(CaseClient.class);
+
+  private final QidUacBuilder qidUacBuilder = new QidUacBuilder(uacQidLinkRepository, caseClient);
+
+  private static final String TEST_PACK_CODE = "TEST";
+  private static final EasyRandom easyRandom = new EasyRandom();
 
   @Test
-  public void testEnglishAndWelshQiTupledReturned() {
+  public void testEnglishAndWelshQidTupleReturned() {
     // Given
-    EasyRandom easyRandom = new EasyRandom();
     Case testCase = easyRandom.nextObject(Case.class);
     String uacEng = easyRandom.nextObject(String.class);
     String uacWal = easyRandom.nextObject(String.class);
@@ -49,15 +58,14 @@ public class QidUacBuilderTest {
 
     when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
         .thenReturn(uacQidLinks);
-    QidUacBuilder qidUacBuilder = new QidUacBuilder(uacQidLinkRepository);
 
     testCase.setTreatmentCode(
-        HOUSEHLD_INITIAL_CONTACT_QUESTIONNIARE_TREATMENT_CODE_PREFIX
+        HOUSEHOLD_INITIAL_CONTACT_QUESTIONNAIRE_TREATMENT_CODE_PREFIX
             + "BLAH"
             + WALES_TREATMENT_CODE_SUFFIX);
 
     // when
-    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(testCase);
+    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId().toString());
@@ -75,7 +83,6 @@ public class QidUacBuilderTest {
   @Test
   public void testEnglishOnlyTupleReturned() {
     // Given
-    EasyRandom easyRandom = new EasyRandom();
     Case testCase = easyRandom.nextObject(Case.class);
     String uacEng = easyRandom.nextObject(String.class);
     String qidEng = "0220000010732199";
@@ -89,12 +96,11 @@ public class QidUacBuilderTest {
 
     when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
         .thenReturn(uacQidLinks);
-    QidUacBuilder qidUacBuilder = new QidUacBuilder(uacQidLinkRepository);
 
     testCase.setTreatmentCode("NotWelshTreatmentCode");
 
     // when
-    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(testCase);
+    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId().toString());
@@ -108,7 +114,6 @@ public class QidUacBuilderTest {
   @Test(expected = RuntimeException.class)
   public void testWalesQuestionnaireWithTwoQidUacsWrongEnglish() {
     // Given
-    EasyRandom easyRandom = new EasyRandom();
     Case testCase = easyRandom.nextObject(Case.class);
     String uacEng = easyRandom.nextObject(String.class);
     String uacWal = easyRandom.nextObject(String.class);
@@ -128,16 +133,17 @@ public class QidUacBuilderTest {
 
     when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
         .thenReturn(uacQidLinks);
-    QidUacBuilder qidUacBuilder = new QidUacBuilder(uacQidLinkRepository);
 
-    // when
-    qidUacBuilder.getUacQidLinks(testCase);
+    // When
+    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+
+    // Then
+    // Exception thrown - expected
   }
 
   @Test(expected = RuntimeException.class)
   public void testWalesQuestionnaireWithTwoQidUacsWrongWelsh() {
     // Given
-    EasyRandom easyRandom = new EasyRandom();
     Case testCase = easyRandom.nextObject(Case.class);
     String uacEng = easyRandom.nextObject(String.class);
     String uacWal = easyRandom.nextObject(String.class);
@@ -157,16 +163,17 @@ public class QidUacBuilderTest {
 
     when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
         .thenReturn(uacQidLinks);
-    QidUacBuilder qidUacBuilder = new QidUacBuilder(uacQidLinkRepository);
 
-    // when
-    qidUacBuilder.getUacQidLinks(testCase);
+    // When
+    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+
+    // Then
+    // Exception thrown - expected
   }
 
   @Test(expected = RuntimeException.class)
   public void testWalesQuestionnaireWithTooManyQidUacs() {
     // Given
-    EasyRandom easyRandom = new EasyRandom();
     Case testCase = easyRandom.nextObject(Case.class);
     String uacEng = easyRandom.nextObject(String.class);
     String uacWal = easyRandom.nextObject(String.class);
@@ -191,21 +198,22 @@ public class QidUacBuilderTest {
 
     when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
         .thenReturn(uacQidLinks);
-    QidUacBuilder qidUacBuilder = new QidUacBuilder(uacQidLinkRepository);
 
     testCase.setTreatmentCode(
-        HOUSEHLD_INITIAL_CONTACT_QUESTIONNIARE_TREATMENT_CODE_PREFIX
+        HOUSEHOLD_INITIAL_CONTACT_QUESTIONNAIRE_TREATMENT_CODE_PREFIX
             + "BLAH"
             + WALES_TREATMENT_CODE_SUFFIX);
 
-    // when
-    qidUacBuilder.getUacQidLinks(testCase);
+    // When
+    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+
+    // Then
+    // Exception thrown - expected
   }
 
   @Test(expected = RuntimeException.class)
   public void testWalesQuestionnaireWithMissingQidUac() {
     // Given
-    EasyRandom easyRandom = new EasyRandom();
     Case testCase = easyRandom.nextObject(Case.class);
     String uacEng = easyRandom.nextObject(String.class);
     String qidEng = "0220000010732199";
@@ -219,21 +227,22 @@ public class QidUacBuilderTest {
 
     when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
         .thenReturn(uacQidLinks);
-    QidUacBuilder qidUacBuilder = new QidUacBuilder(uacQidLinkRepository);
 
     testCase.setTreatmentCode(
-        HOUSEHLD_INITIAL_CONTACT_QUESTIONNIARE_TREATMENT_CODE_PREFIX
+        HOUSEHOLD_INITIAL_CONTACT_QUESTIONNAIRE_TREATMENT_CODE_PREFIX
             + "BLAH"
             + WALES_TREATMENT_CODE_SUFFIX);
 
-    // when
-    qidUacBuilder.getUacQidLinks(testCase);
+    // When
+    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+
+    // Then
+    // Exception thrown - expected
   }
 
   @Test(expected = RuntimeException.class)
   public void testQidLinksEmpty() {
     // Given
-    EasyRandom easyRandom = new EasyRandom();
     ActionPlan actionPlan = easyRandom.nextObject(ActionPlan.class);
     ActionRule actionRule = new ActionRule();
     actionRule.setActionPlan(actionPlan);
@@ -245,14 +254,15 @@ public class QidUacBuilderTest {
         .thenReturn(Collections.EMPTY_LIST);
 
     // When
-    QidUacBuilder qidUacBuilder = new QidUacBuilder(uacQidLinkRepository);
-    qidUacBuilder.getUacQidLinks(testCase);
+    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+
+    // Then
+    // Exception thrown - expected
   }
 
   @Test(expected = RuntimeException.class)
-  public void testMulitpleQidLinksAmbiguous() {
+  public void testMultipleQidLinksAmbiguous() {
     // Given
-    EasyRandom easyRandom = new EasyRandom();
     ActionPlan actionPlan = easyRandom.nextObject(ActionPlan.class);
     ActionRule actionRule = new ActionRule();
     actionRule.setActionPlan(actionPlan);
@@ -280,7 +290,153 @@ public class QidUacBuilderTest {
         .thenReturn(uacQidLinks);
 
     // When
-    QidUacBuilder qidUacBuilder = new QidUacBuilder(uacQidLinkRepository);
-    qidUacBuilder.getUacQidLinks(testCase);
+    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+
+    // Then
+    // Exception thrown - expected
+  }
+
+  @Test
+  public void testNewUacIsRequestedForReminderLetterPackCode() {
+    // Given
+    Case linkedCase = easyRandom.nextObject(Case.class);
+    linkedCase.setTreatmentCode("HH_LF2R1E");
+    String reminderLetterPackCode = "P_RL_1RL1_1";
+    String expectedQuestionnaireType = "1";
+    UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
+    when(caseClient.getUacQid(eq(linkedCase.getCaseId()), eq(expectedQuestionnaireType)))
+        .thenReturn(uacQidDTO);
+
+    // When
+    UacQidTuple actualUacQidTuple =
+        qidUacBuilder.getUacQidLinks(linkedCase, reminderLetterPackCode);
+
+    // Then
+    verify(caseClient).getUacQid(eq(linkedCase.getCaseId()), eq(expectedQuestionnaireType));
+    assertThat(actualUacQidTuple.getUacQidLink())
+        .isEqualToComparingOnlyGivenFields(uacQidDTO, "uac", "qid");
+    assertThat(actualUacQidTuple.getUacQidLink().getCaseId())
+        .isEqualTo(linkedCase.getCaseId().toString());
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeEnglandHousehold() {
+    // Given
+
+    // When
+    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("HH_LF2R3BE");
+
+    // Then
+    assertEquals(1, actualQuestionnaireType);
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeWalesHousehold() {
+    // Given
+
+    // When
+    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("HH_LF2R1W");
+
+    // Then
+    assertEquals(2, actualQuestionnaireType);
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeNorthernIrelandHousehold() {
+    // Given
+
+    // When
+    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("HH_1LSFN");
+
+    // Then
+    assertEquals(4, actualQuestionnaireType);
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeEnglandIndividual() {
+    // Given
+
+    // When
+    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CI_L666E");
+
+    // Then
+    assertEquals(21, actualQuestionnaireType);
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeWalesIndividual() {
+    // Given
+
+    // When
+    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CI_L666W");
+
+    // Then
+    assertEquals(22, actualQuestionnaireType);
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeNorthernIrelandIndividual() {
+    // Given
+
+    // When
+    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CI_L666N");
+
+    // Then
+    assertEquals(24, actualQuestionnaireType);
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeEnglandCommunalEstablishment() {
+    // Given
+
+    // When
+    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CE_L666E");
+
+    // Then
+    assertEquals(31, actualQuestionnaireType);
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeWalesCommunalEstablishment() {
+    // Given
+
+    // When
+    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CE_L666W");
+
+    // Then
+    assertEquals(32, actualQuestionnaireType);
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeNorthernIrelandCommunalEstablishment() {
+    // Given
+
+    // When
+    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CE_L666N");
+
+    // Then
+    assertEquals(34, actualQuestionnaireType);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidCountryTreatmentCode() {
+    // Given
+
+    // When
+    QidUacBuilder.calculateQuestionnaireType("CE_L666X");
+
+    // Then
+    // Exception thrown - expected
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidCaseType() {
+    // Given
+
+    // When
+    QidUacBuilder.calculateQuestionnaireType("ZZ_L666E");
+
+    // Then
+    // Exception thrown - expected
   }
 }

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -72,8 +72,7 @@ public class ActionRuleProcessorIT {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  @Rule
-  public WireMockRule mockCaseApi = new WireMockRule(wireMockConfig().port(8089));
+  @Rule public WireMockRule mockCaseApi = new WireMockRule(wireMockConfig().port(8089));
 
   @Test
   public void testReminderLetterActionCreatesNewUac() throws IOException, InterruptedException {

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.jeasy.random.EasyRandom;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +33,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.action.messaging.RabbitQueueHelper;
 import uk.gov.ons.census.action.model.dto.PrintFileDto;
 import uk.gov.ons.census.action.model.dto.UacQidDTO;
@@ -69,6 +71,17 @@ public class ActionRuleProcessorIT {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Rule public WireMockRule mockCaseApi = new WireMockRule(wireMockConfig().port(8089));
+
+  @Before
+  @Transactional
+  public void setUp() {
+    rabbitQueueHelper.purgeQueue(outboundPrinterQueue);
+    caseRepository.deleteAllInBatch();
+    actionRuleRepository.deleteAllInBatch();
+    actionPlanRepository.deleteAll();
+    actionRuleRepository.deleteAll();
+    actionPlanRepository.deleteAllInBatch();
+  }
 
   @Test
   public void testReminderLetterActionCreatesNewUac() throws IOException, InterruptedException {

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -73,7 +73,7 @@ public class ActionRuleProcessorIT {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Rule
-  public WireMockRule mockCaseApi = new WireMockRule(wireMockConfig().port(8089).httpsPort(8443));
+  public WireMockRule mockCaseApi = new WireMockRule(wireMockConfig().port(8089));
 
   @Test
   public void testReminderLetterActionCreatesNewUac() throws IOException, InterruptedException {

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -1,0 +1,157 @@
+package uk.gov.ons.census.action.schedule;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.jeasy.random.EasyRandom;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.gov.ons.census.action.messaging.RabbitQueueHelper;
+import uk.gov.ons.census.action.model.dto.PrintFileDto;
+import uk.gov.ons.census.action.model.dto.UacQidDTO;
+import uk.gov.ons.census.action.model.entity.ActionPlan;
+import uk.gov.ons.census.action.model.entity.ActionRule;
+import uk.gov.ons.census.action.model.entity.ActionType;
+import uk.gov.ons.census.action.model.entity.Case;
+import uk.gov.ons.census.action.model.repository.ActionPlanRepository;
+import uk.gov.ons.census.action.model.repository.ActionRuleRepository;
+import uk.gov.ons.census.action.model.repository.CaseRepository;
+import uk.gov.ons.census.action.model.repository.UacQidLinkRepository;
+
+@ContextConfiguration
+@SpringBootTest
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ActionRuleProcessorIT {
+
+  private static final int DELAY_ACTION_BY_SECONDS = 5;
+
+  @Value("${queueconfig.outbound-printer-queue}")
+  private String outboundPrinterQueue;
+
+  @Autowired private RabbitQueueHelper rabbitQueueHelper;
+  @Autowired private CaseRepository caseRepository;
+  @Autowired private UacQidLinkRepository uacQidLinkRepository;
+  @Autowired private ActionRuleRepository actionRuleRepository;
+  @Autowired private ActionPlanRepository actionPlanRepository;
+  @Autowired private ActionRuleProcessor actionRuleProcessor;
+  private static final EasyRandom easyRandom = new EasyRandom();
+
+  @Value("${caseapi.port}")
+  private int caseApiPort;
+
+  @Value("${caseapi.host}")
+  private String caseApiHost;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Rule
+  public WireMockRule mockCaseApi = new WireMockRule(wireMockConfig().port(8089).httpsPort(8443));
+
+  @Test
+  public void testReminderLetterActionCreatesNewUac() throws IOException, InterruptedException {
+    // Given
+    UacQidDTO uacQidDto = easyRandom.nextObject(UacQidDTO.class);
+    String returnJson = objectMapper.writeValueAsString(uacQidDto);
+    String uacCreateUrl = "/uacqid/create/";
+    stubFor(
+        post(urlEqualTo(uacCreateUrl))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.OK.value())
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(returnJson)));
+    BlockingQueue<String> printerQueue = rabbitQueueHelper.listen(outboundPrinterQueue);
+    ActionPlan actionPlan = setUpActionPlan();
+    Case randomCase = setUpCase(actionPlan);
+    ActionRule actionRule = setUpActionRule(ActionType.P_RL_1RL1_1, actionPlan);
+
+    // When the action plan triggers
+    String actualMessage = printerQueue.poll(20, TimeUnit.SECONDS);
+
+    // Then
+    assertThat(actualMessage).isNotNull();
+    PrintFileDto actualPrintFileDto = objectMapper.readValue(actualMessage, PrintFileDto.class);
+    verify(exactly(1), postRequestedFor(urlEqualTo(uacCreateUrl)));
+
+    assertThat(actualPrintFileDto.getActionType()).isEqualTo(ActionType.P_RL_1RL1_1.name());
+    assertThat(actualPrintFileDto.getPackCode()).isEqualTo(ActionType.P_RL_1RL1_1.name());
+    assertThat(actualPrintFileDto).isEqualToComparingOnlyGivenFields(uacQidDto, "uac", "qid");
+    assertThat(actualPrintFileDto)
+        .isEqualToIgnoringGivenFields(
+            randomCase,
+            "uac",
+            "qid",
+            "uacWales",
+            "qidWales",
+            "title",
+            "forename",
+            "surname",
+            "batchId",
+            "batchQuantity",
+            "packCode",
+            "actionType");
+  }
+
+  private ActionPlan setUpActionPlan() {
+    ActionPlan actionPlan = new ActionPlan();
+    actionPlan.setId(UUID.randomUUID());
+    actionPlan.setDescription("Test Reminder Letters");
+    actionPlan.setName("Test Reminder Letters");
+    actionPlan.setActionRules(null);
+    actionPlanRepository.saveAndFlush(actionPlan);
+    return actionPlan;
+  }
+
+  private ActionRule setUpActionRule(ActionType actionType, ActionPlan actionPlan) {
+    ActionRule actionRule = new ActionRule();
+    actionRule.setId(UUID.randomUUID());
+    actionRule.setTriggerDateTime(OffsetDateTime.now());
+    actionRule.setHasTriggered(false);
+    actionRule.setActionType(actionType);
+    actionRule.setActionPlan(actionPlan);
+
+    Map<String, List<String>> classifiers = new HashMap<>();
+    actionRule.setClassifiers(classifiers);
+
+    actionRuleRepository.saveAndFlush(actionRule);
+    return actionRule;
+  }
+
+  private Case setUpCase(ActionPlan actionPlan) {
+    Case randomCase = easyRandom.nextObject(Case.class);
+    randomCase.setActionPlanId(actionPlan.getId().toString());
+    randomCase.setReceiptReceived(false);
+    randomCase.setRefusalReceived(false);
+    randomCase.setTreatmentCode("HH_LF2R1E");
+    caseRepository.saveAndFlush(randomCase);
+    return randomCase;
+  }
+}

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -32,6 +32,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.gov.ons.census.action.builders.PrintFileDtoBuilder;
+import uk.gov.ons.census.action.builders.QidUacBuilder;
 import uk.gov.ons.census.action.messaging.RabbitQueueHelper;
 import uk.gov.ons.census.action.model.dto.PrintFileDto;
 import uk.gov.ons.census.action.model.dto.UacQidDTO;
@@ -51,17 +53,14 @@ import uk.gov.ons.census.action.model.repository.UacQidLinkRepository;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ActionRuleProcessorIT {
 
-  private static final int DELAY_ACTION_BY_SECONDS = 5;
-
   @Value("${queueconfig.outbound-printer-queue}")
   private String outboundPrinterQueue;
 
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
   @Autowired private CaseRepository caseRepository;
-  @Autowired private UacQidLinkRepository uacQidLinkRepository;
   @Autowired private ActionRuleRepository actionRuleRepository;
   @Autowired private ActionPlanRepository actionPlanRepository;
-  @Autowired private ActionRuleProcessor actionRuleProcessor;
+
   private static final EasyRandom easyRandom = new EasyRandom();
 
   @Value("${caseapi.port}")
@@ -149,6 +148,7 @@ public class ActionRuleProcessorIT {
     randomCase.setActionPlanId(actionPlan.getId().toString());
     randomCase.setReceiptReceived(false);
     randomCase.setRefusalReceived(false);
+    randomCase.setAddressInvalid(false);
     randomCase.setTreatmentCode("HH_LF2R1E");
     caseRepository.saveAndFlush(randomCase);
     return randomCase;

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -32,8 +32,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import uk.gov.ons.census.action.builders.PrintFileDtoBuilder;
-import uk.gov.ons.census.action.builders.QidUacBuilder;
 import uk.gov.ons.census.action.messaging.RabbitQueueHelper;
 import uk.gov.ons.census.action.model.dto.PrintFileDto;
 import uk.gov.ons.census.action.model.dto.UacQidDTO;
@@ -44,7 +42,6 @@ import uk.gov.ons.census.action.model.entity.Case;
 import uk.gov.ons.census.action.model.repository.ActionPlanRepository;
 import uk.gov.ons.census.action.model.repository.ActionRuleRepository;
 import uk.gov.ons.census.action.model.repository.CaseRepository;
-import uk.gov.ons.census.action.model.repository.UacQidLinkRepository;
 
 @ContextConfiguration
 @SpringBootTest

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
@@ -48,7 +48,7 @@ public class ActionRuleProcessorTest {
   @Test
   public void testExecuteClassifiers() {
     // Given
-    ActionRule actionRule = setUpActionRule();
+    ActionRule actionRule = setUpActionRule(ActionType.ICL1E);
     Map<String, List<String>> classifiers = new HashMap<>();
     List<String> columnValues = Arrays.asList("a", "b", "c");
     classifiers.put("A_Column", columnValues);
@@ -93,7 +93,7 @@ public class ActionRuleProcessorTest {
   @Test
   public void testExecuteCasesField() {
     // Given
-    ActionRule actionRule = setUpActionRuleField();
+    ActionRule actionRule = setUpActionRule(ActionType.FF2QE);
     final int expectedCaseCount = 50;
 
     List<Case> cases = getRandomCases(expectedCaseCount);
@@ -135,7 +135,7 @@ public class ActionRuleProcessorTest {
   @Test
   public void testExceptionInThreadCausesException() {
     // Given
-    ActionRule actionRule = setUpActionRule();
+    ActionRule actionRule = setUpActionRule(ActionType.ICL1E);
 
     List<Case> cases = getRandomCases(50);
     // when
@@ -181,7 +181,7 @@ public class ActionRuleProcessorTest {
   @Test(expected = RuntimeException.class)
   public void testRabbitBlowsUpThrowsException() {
     // Given
-    ActionRule actionRule = setUpActionRule();
+    ActionRule actionRule = setUpActionRule(ActionType.ICL1E);
 
     List<Case> cases = getRandomCases(50);
     // when
@@ -215,7 +215,7 @@ public class ActionRuleProcessorTest {
     // exception thrown
   }
 
-  private ActionRule setUpActionRule() {
+  private ActionRule setUpActionRule(ActionType actionType) {
     ActionRule actionRule = new ActionRule();
     UUID actionRuleId = UUID.randomUUID();
     actionRule.setId(actionRuleId);
@@ -226,31 +226,9 @@ public class ActionRuleProcessorTest {
     classifiers.put("A Key", new ArrayList<>());
 
     actionRule.setClassifiers(classifiers);
-    actionRule.setActionType(ActionType.ICL1E);
+    actionRule.setActionType(actionType);
 
     ActionPlan actionPlan = new ActionPlan();
-    actionPlan.setId(UUID.randomUUID());
-
-    actionRule.setActionPlan(actionPlan);
-
-    return actionRule;
-  }
-
-  private ActionRule setUpActionRuleField() {
-    ActionRule actionRule = new ActionRule();
-    UUID actionRuleId = UUID.randomUUID();
-    actionRule.setId(actionRuleId);
-    actionRule.setTriggerDateTime(OffsetDateTime.now());
-    actionRule.setHasTriggered(false);
-    actionRule.setClassifiers(new HashMap<>());
-    actionRule.setActionType(ActionType.FF2QE);
-
-    ActionPlan actionPlan = new ActionPlan();
-
-    Map<String, List<String>> classifiers = new HashMap<>();
-    classifiers.put("A Key", new ArrayList<>());
-
-    actionRule.setClassifiers(classifiers);
     actionPlan.setId(UUID.randomUUID());
 
     actionRule.setActionPlan(actionPlan);


### PR DESCRIPTION
# Motivation and Context
Action scheduler needs to schedule remind letters.

# What has changed
* Add action types for reminder letters
* Create new UAC QID pair for reminder pack codes
* Calculate questionnaire type from treatment code
* Unit tests for calculating questionnaire type and requesting new UAC QID pairs

# How to test?
Run a maven build on this branch, build the linked branch of print file service then run the linked branch of acceptance tests

# Links
https://trello.com/c/9WfpfHYE/721-rmc-138-schedule-generate-and-distribute-reminder-letters-5
https://github.com/ONSdigital/census-rm-print-file-service/pull/11
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/112