### PR TITLE
Exclude cases with invalid address

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.census.action.builders;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.census.action.model.dto.FieldworkFollowup;
 import uk.gov.ons.census.action.model.entity.ActionRule;
@@ -8,9 +7,6 @@ import uk.gov.ons.census.action.model.entity.Case;
 
 @Component
 public class FieldworkFollowupBuilder {
-
-  @Value("${queueconfig.outbound-exchange}")
-  private String outboundExchange;
 
   public FieldworkFollowup buildFieldworkFollowup(Case caze, ActionRule actionRule) {
 

--- a/src/main/java/uk/gov/ons/census/action/messaging/EventReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/EventReceiver.java
@@ -70,8 +70,6 @@ public class EventReceiver {
   private void setCaseDetails(CollectionCase collectionCase, Case caseDetails) {
     caseDetails.setCaseRef(Integer.parseInt(collectionCase.getCaseRef()));
     caseDetails.setCaseId(UUID.fromString(collectionCase.getId()));
-    caseDetails.setCaseRef(Integer.parseInt(collectionCase.getCaseRef()));
-    caseDetails.setCaseId(UUID.fromString(collectionCase.getId()));
     caseDetails.setState(CaseState.valueOf(collectionCase.getState()));
     caseDetails.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
     caseDetails.setAddressLine1(collectionCase.getAddress().getAddressLine1());

--- a/src/main/java/uk/gov/ons/census/action/messaging/EventReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/EventReceiver.java
@@ -8,7 +8,6 @@ import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.action.model.dto.CollectionCase;
-import uk.gov.ons.census.action.model.dto.Event;
 import uk.gov.ons.census.action.model.dto.EventType;
 import uk.gov.ons.census.action.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.action.model.dto.Uac;
@@ -39,9 +38,7 @@ public class EventReceiver {
     } else if (responseManagementEvent.getEvent().getType() == EventType.UAC_UPDATED) {
       processUacUpdated(responseManagementEvent.getPayload().getUac());
     } else if (responseManagementEvent.getEvent().getType() == EventType.CASE_UPDATED) {
-      processCaseUpdatedEvent(
-          responseManagementEvent.getEvent(),
-          responseManagementEvent.getPayload().getCollectionCase());
+      processCaseUpdatedEvent(responseManagementEvent.getPayload().getCollectionCase());
     } else {
       // This code can't be reached because under the class structure the EventType is limited to
       // enums at this point?
@@ -51,14 +48,11 @@ public class EventReceiver {
 
   private void processCaseCreatedEvent(CollectionCase collectionCase) {
     Case newCase = new Case();
-    newCase.setCaseRef(Integer.parseInt(collectionCase.getCaseRef()));
-    newCase.setCaseId(UUID.fromString(collectionCase.getId()));
     setCaseDetails(collectionCase, newCase);
-    newCase.setReceiptReceived(false);
     caseRepository.save(newCase);
   }
 
-  private void processCaseUpdatedEvent(Event event, CollectionCase collectionCase) {
+  private void processCaseUpdatedEvent(CollectionCase collectionCase) {
     String caseId = collectionCase.getId();
 
     Optional<Case> cazeOpt = caseRepository.findByCaseId(UUID.fromString(caseId));
@@ -69,12 +63,15 @@ public class EventReceiver {
     }
 
     Case updatedCase = cazeOpt.get();
-    updatedCase.setCaseId(UUID.fromString(caseId));
     setCaseDetails(collectionCase, updatedCase);
     caseRepository.save(updatedCase);
   }
 
   private void setCaseDetails(CollectionCase collectionCase, Case caseDetails) {
+    caseDetails.setCaseRef(Integer.parseInt(collectionCase.getCaseRef()));
+    caseDetails.setCaseId(UUID.fromString(collectionCase.getId()));
+    caseDetails.setCaseRef(Integer.parseInt(collectionCase.getCaseRef()));
+    caseDetails.setCaseId(UUID.fromString(collectionCase.getId()));
     caseDetails.setState(CaseState.valueOf(collectionCase.getState()));
     caseDetails.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
     caseDetails.setAddressLine1(collectionCase.getAddress().getAddressLine1());
@@ -107,15 +104,8 @@ public class EventReceiver {
     caseDetails.setFieldCoordinatorId(collectionCase.getFieldCoordinatorId());
     caseDetails.setFieldOfficerId(collectionCase.getFieldOfficerId());
     caseDetails.setCeExpectedCapacity(collectionCase.getCeExpectedCapacity());
-
-    if (collectionCase.getReceiptReceived() != null) {
-      caseDetails.setReceiptReceived(collectionCase.getReceiptReceived());
-    }
-
-    if (collectionCase.getRefusalReceived() != null) {
-      caseDetails.setRefusalReceived(collectionCase.getRefusalReceived());
-    }
-
+    caseDetails.setReceiptReceived(collectionCase.getReceiptReceived());
+    caseDetails.setRefusalReceived(collectionCase.getRefusalReceived());
     caseDetails.setAddressInvalid(collectionCase.getAddressInvalid());
   }
 

--- a/src/main/java/uk/gov/ons/census/action/messaging/EventReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/EventReceiver.java
@@ -115,6 +115,8 @@ public class EventReceiver {
     if (collectionCase.getRefusalReceived() != null) {
       caseDetails.setRefusalReceived(collectionCase.getRefusalReceived());
     }
+
+    caseDetails.setAddressInvalid(collectionCase.getAddressInvalid());
   }
 
   private void processUacUpdated(Uac uac) {

--- a/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
@@ -25,4 +25,5 @@ public class CollectionCase {
   private String ceExpectedCapacity;
   private Boolean receiptReceived;
   private Boolean refusalReceived;
+  private Boolean addressInvalid;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -86,4 +86,7 @@ public class Case {
 
   @Column(name = "refusal_received", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean refusalReceived;
+
+  @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+  private boolean addressInvalid;
 }

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
@@ -179,7 +179,7 @@ public class ActionRuleProcessor {
 
   private Specification<Case> createSpecificationForActionableCases(String actionPlanId) {
     return where(isActionPlanIdEqualTo(actionPlanId))
-        .and(excludeReceiptedCases().and(excludeRefusedCases()));
+        .and(excludeReceiptedCases().and(excludeRefusedCases()).and(excludeAddressInvalidCases()));
   }
 
   private Specification<Case> isActionPlanIdEqualTo(String actionPlanId) {
@@ -195,6 +195,11 @@ public class ActionRuleProcessor {
   private Specification<Case> excludeRefusedCases() {
     return (Specification<Case>)
         (root, query, builder) -> builder.equal(root.get("refusalReceived"), false);
+  }
+
+  private Specification<Case> excludeAddressInvalidCases() {
+    return (Specification<Case>)
+        (root, query, builder) -> builder.equal(root.get("addressInvalid"), false);
   }
 
   private Specification<Case> isClassifierIn(

--- a/src/test/java/uk.gov.ons.census.action/messaging/ConsumeAndPublishIT.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/ConsumeAndPublishIT.java
@@ -328,6 +328,7 @@ public class ConsumeAndPublishIT {
         .getAddress()
         .setLongitude(Double.toString(random.nextDouble()));
 
+    responseManagementEvent.getPayload().getCollectionCase().setReceiptReceived(false);
     responseManagementEvent.getPayload().getCollectionCase().setRefusalReceived(false);
     responseManagementEvent.getPayload().getCollectionCase().setAddressInvalid(false);
 

--- a/src/test/java/uk.gov.ons.census.action/messaging/EventReceiverTest.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/EventReceiverTest.java
@@ -113,6 +113,7 @@ public class EventReceiverTest {
     newCase.setFieldCoordinatorId(collectionCase.getFieldCoordinatorId());
     newCase.setFieldOfficerId(collectionCase.getFieldOfficerId());
     newCase.setCeExpectedCapacity(collectionCase.getCeExpectedCapacity());
+    newCase.setAddressInvalid(collectionCase.getAddressInvalid());
     return newCase;
   }
 }

--- a/src/test/java/uk.gov.ons.census.action/messaging/EventReceiverTest.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/EventReceiverTest.java
@@ -76,6 +76,8 @@ public class EventReceiverTest {
         .getCollectionCase()
         .setId("d09ac28e-d62f-4cdd-a5f9-e366e05f0fcd");
     responseManagementEvent.getPayload().getCollectionCase().setState("ACTIONABLE");
+    responseManagementEvent.getPayload().getCollectionCase().setReceiptReceived(false);
+    responseManagementEvent.getPayload().getCollectionCase().setRefusalReceived(false);
     return responseManagementEvent;
   }
 


### PR DESCRIPTION
# Motivation and Context
Fieldwork might discover that an address is not valid and notify RM via a message. We need to handle that message so that we cease doing follow-up actions and we know why we haven't had a response.

# What has changed
Excluded cases with invalid address from action plans.

# How to test?
Run the acceptance tests with Case Processor on the same branch name.

# Links
Trello: https://trello.com/c/bKxycLe3