### PR TITLE
Implement Continuation PQ requested event

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/messaging/FulfilmentRequestReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/FulfilmentRequestReceiver.java
@@ -100,6 +100,10 @@ public class FulfilmentRequestReceiver {
       case "P_OR_H2":
       case "P_OR_H2W":
       case "P_OR_H4":
+      case "P_OR_HC1":
+      case "P_OR_HC2":
+      case "P_OR_HC2W":
+      case "P_OR_HC4":
         return Optional.of(ActionType.P_OR_HX);
       case "P_LP_HL1":
       case "P_LP_HL2":
@@ -152,7 +156,11 @@ public class FulfilmentRequestReceiver {
           "P_OR_H1", 1,
           "P_OR_H2", 2,
           "P_OR_H2W", 3,
-          "P_OR_H4", 4);
+          "P_OR_H4", 4,
+          "P_OR_HC1", 11,
+          "P_OR_HC2", 12,
+          "P_OR_HC2W", 13,
+          "P_OR_HC4", 14);
 
   private Optional<Integer> determineQuestionnaireType(String packCode) {
     return Optional.ofNullable(fulfilmentCodeToQuestionnaireType.get(packCode));

--- a/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverIT.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverIT.java
@@ -99,6 +99,38 @@ public class FulfilmentRequestReceiverIT {
   }
 
   @Test
+  public void testContinuationQuestionnaireFulfilment() throws InterruptedException, IOException {
+
+    // Given
+    BlockingQueue<String> outputQueue = rabbitQueueHelper.listen(outboundPrinterQueue);
+    Case fulfillmentCase = this.setUpCase();
+    ResponseManagementEvent actionFulfilmentEvent =
+        getResponseManagementEvent(fulfillmentCase.getCaseId(), "P_OR_HC1");
+    String url = "/uacqid/create/";
+    UacQidDTO uacQidDto = easyRandom.nextObject(UacQidDTO.class);
+    String returnJson = objectMapper.writeValueAsString(uacQidDto);
+    givenThat(
+        post(urlEqualTo(url))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.OK.value())
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(returnJson)));
+
+    // When
+    rabbitQueueHelper.sendMessage(
+        eventsExchange, eventsFulfilmentRequestBinding, actionFulfilmentEvent);
+
+    // Then
+    PrintFileDto actualPrintFileDto = checkExpectedPrintFileDtoMessageReceived(outputQueue);
+    checkAddressFieldsMatch(
+        fulfillmentCase,
+        actionFulfilmentEvent.getPayload().getFulfilmentRequest().getContact(),
+        actualPrintFileDto);
+    assertThat(actualPrintFileDto).isEqualToComparingOnlyGivenFields(uacQidDto, "uac", "qid");
+  }
+
+  @Test
   public void testLargePrintQuestionnaireFulfilment() throws InterruptedException, IOException {
 
     // Given

--- a/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverTest.java
+++ b/src/test/java/uk.gov.ons.census.action/messaging/FulfilmentRequestReceiverTest.java
@@ -88,6 +88,24 @@ public class FulfilmentRequestReceiverTest {
   }
 
   @Test
+  public void testOnRequestContinuationQuestionnaireFulfilment() {
+    // Given
+    Case fulfilmentCase = caseRepositoryReturnsRandomCase();
+    ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
+    event.getPayload().getFulfilmentRequest().setFulfilmentCode("P_OR_HC1");
+    UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
+    when(caseClient.getUacQid(eq(fulfilmentCase.getCaseId()), eq("11"))).thenReturn(uacQidDTO);
+
+    // When
+    underTest.receiveEvent(event);
+
+    // Then
+    PrintFileDto actualPrintFileDTO =
+        checkCorrectPackCodeAndAddressAreSent(event, fulfilmentCase, ActionType.P_OR_HX);
+    assertThat(actualPrintFileDTO).isEqualToComparingOnlyGivenFields(uacQidDTO, "uac", "qid");
+  }
+
+  @Test
   public void testLargePrintQuestionnaireFulfilment() {
     // Given
     Case fulfilmentCase = caseRepositoryReturnsRandomCase();


### PR DESCRIPTION
# Motivation and Context
Members of a household need to be able to request continuation paper questionnaires
<!--- Why is this change required? What problem does it solve? -->

# What has changed
Added "P_OR_HC1", "P_OR_HC2", "P_OR_HC2W" & "P_OR_HC4" fulfilment codes
Added questionnaire type mapping for new codes
Added Continuation Questionnaire Fulfilment IT
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
Build local docker images of this branch and [this PR](https://github.com/ONSdigital/census-rm-print-file-service/pull/12) and run with docker dev
Run tests
Run acceptance tests from [this PR](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/115)
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
[Trello](https://trello.com/c/SOmfsH8H/996-rmc-134c1-implement-continuation-pq-requested-event-5)
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):