### PR TITLE
RMC-157 Scheduled Reminder Questionnaires

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.census.action.model.UacQidTuple;
 import uk.gov.ons.census.action.model.dto.PrintFileDto;
+import uk.gov.ons.census.action.model.entity.ActionType;
 import uk.gov.ons.census.action.model.entity.Case;
 
 @Component
@@ -15,9 +16,9 @@ public class PrintFileDtoBuilder {
   }
 
   public PrintFileDto buildPrintFileDto(
-      Case selectedCase, String packCode, UUID batchUUID, String actionType) {
+      Case selectedCase, String packCode, UUID batchUUID, ActionType actionType) {
 
-    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(selectedCase, packCode);
+    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(selectedCase, actionType);
 
     PrintFileDto printFileDto = new PrintFileDto();
     printFileDto.setUac(uacQidTuple.getUacQidLink().getUac());
@@ -36,7 +37,7 @@ public class PrintFileDtoBuilder {
     printFileDto.setPostcode(selectedCase.getPostcode());
     printFileDto.setBatchId(batchUUID.toString());
     printFileDto.setPackCode(packCode);
-    printFileDto.setActionType(actionType);
+    printFileDto.setActionType(actionType.toString());
     printFileDto.setFieldCoordinatorId(selectedCase.getFieldCoordinatorId());
 
     return printFileDto;

--- a/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
@@ -60,10 +60,10 @@ public class QidUacBuilder {
       throw new RuntimeException(); // We can't process this case with no UACs
 
     } else if (isStateCorrectForSingleUacQidPair(linkedCase, uacQidLinks)) {
-      return createUacQidTupleWithSinglePair(uacQidLinks);
+      return getUacQidTupleWithSinglePair(uacQidLinks);
 
     } else if (isStateCorrectForSecondWelshUacQidPair(linkedCase, uacQidLinks)) {
-      return createUacQidTupleWithSecondWelshPair(uacQidLinks);
+      return getUacQidTupleWithSecondWelshPair(uacQidLinks);
 
     } else {
       throw new RuntimeException(); // We can't process this case with the wrong number of UACs for
@@ -83,13 +83,13 @@ public class QidUacBuilder {
             == NUM_OF_UAC_QID_PAIRS_NEEDED_BY_A_WALES_INITIAL_CONTACT_QUESTIONNAIRE;
   }
 
-  private UacQidTuple createUacQidTupleWithSinglePair(List<UacQidLink> uacQidLinks) {
+  private UacQidTuple getUacQidTupleWithSinglePair(List<UacQidLink> uacQidLinks) {
     UacQidTuple uacQidTuple = new UacQidTuple();
     uacQidTuple.setUacQidLink(uacQidLinks.get(0));
     return uacQidTuple;
   }
 
-  private UacQidTuple createUacQidTupleWithSecondWelshPair(List<UacQidLink> uacQidLinks) {
+  private UacQidTuple getUacQidTupleWithSecondWelshPair(List<UacQidLink> uacQidLinks) {
     UacQidTuple uacQidTuple = new UacQidTuple();
     uacQidTuple.setUacQidLink(
         getSpecificUacQidLinkByQuestionnaireType(
@@ -108,7 +108,7 @@ public class QidUacBuilder {
     uacQidTuple.setUacQidLink(
         createNewUacQidPair(
             linkedCase,
-            Integer.toString(calculateQuestionnaireType(linkedCase.getTreatmentCode()))));
+            calculateQuestionnaireType(linkedCase.getTreatmentCode())));
     if (packCode.equals(ActionType.P_QU_H2.name())) {
       uacQidTuple.setUacQidLinkWales(
           Optional.of(createNewUacQidPair(linkedCase, WALES_IN_WELSH_QUESTIONNAIRE_TYPE)));
@@ -152,7 +152,7 @@ public class QidUacBuilder {
     return packCodesRequiringNewUacQidPair.contains(packCode);
   }
 
-  public static int calculateQuestionnaireType(String treatmentCode) {
+  public static String calculateQuestionnaireType(String treatmentCode) {
     String country = treatmentCode.substring(treatmentCode.length() - 1);
     if (!country.equals("E") && !country.equals("W") && !country.equals("N")) {
       log.with("treatment_code", treatmentCode).error(UNKNOWN_COUNTRY_ERROR);
@@ -162,29 +162,29 @@ public class QidUacBuilder {
     if (treatmentCode.startsWith("HH")) {
       switch (country) {
         case "E":
-          return 1;
+          return "01";
         case "W":
-          return 2;
+          return "02";
         case "N":
-          return 4;
+          return "04";
       }
     } else if (treatmentCode.startsWith("CI")) {
       switch (country) {
         case "E":
-          return 21;
+          return "21";
         case "W":
-          return 22;
+          return "22";
         case "N":
-          return 24;
+          return "24";
       }
     } else if (treatmentCode.startsWith("CE")) {
       switch (country) {
         case "E":
-          return 31;
+          return "31";
         case "W":
-          return 32;
+          return "32";
         case "N":
-          return 34;
+          return "34";
       }
     } else {
       log.with("treatment_code", treatmentCode).error(UNEXPECTED_CASE_TYPE_ERROR);

--- a/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
@@ -106,9 +106,7 @@ public class QidUacBuilder {
   private UacQidTuple createUacQidTupleWithNewPairs(Case linkedCase, String packCode) {
     UacQidTuple uacQidTuple = new UacQidTuple();
     uacQidTuple.setUacQidLink(
-        createNewUacQidPair(
-            linkedCase,
-            calculateQuestionnaireType(linkedCase.getTreatmentCode())));
+        createNewUacQidPair(linkedCase, calculateQuestionnaireType(linkedCase.getTreatmentCode())));
     if (packCode.equals(ActionType.P_QU_H2.name())) {
       uacQidTuple.setUacQidLinkWales(
           Optional.of(createNewUacQidPair(linkedCase, WALES_IN_WELSH_QUESTIONNAIRE_TYPE)));

--- a/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
@@ -57,7 +57,7 @@ public class QidUacBuilder {
         uacQidLinkRepository.findByCaseId(linkedCase.getCaseId().toString());
 
     if (uacQidLinks == null || uacQidLinks.isEmpty()) {
-      throw new RuntimeException(); // We can't process this case with UACs
+      throw new RuntimeException(); // We can't process this case with no UACs
 
     } else if (isStateCorrectForSingleUacQidPair(linkedCase, uacQidLinks)) {
       return createUacQidTupleWithSinglePair(uacQidLinks);
@@ -66,7 +66,7 @@ public class QidUacBuilder {
       return createUacQidTupleWithSecondWelshPair(uacQidLinks);
 
     } else {
-      throw new RuntimeException(); // We can't process this case with the wrong number of UACs
+      throw new RuntimeException(); // We can't process this case with the wrong number of UACs for it's treatment code
     }
   }
 

--- a/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/QidUacBuilder.java
@@ -66,7 +66,8 @@ public class QidUacBuilder {
       return createUacQidTupleWithSecondWelshPair(uacQidLinks);
 
     } else {
-      throw new RuntimeException(); // We can't process this case with the wrong number of UACs for it's treatment code
+      throw new RuntimeException(); // We can't process this case with the wrong number of UACs for
+      // it's treatment code
     }
   }
 
@@ -105,16 +106,18 @@ public class QidUacBuilder {
   private UacQidTuple createUacQidTupleWithNewPairs(Case linkedCase, String packCode) {
     UacQidTuple uacQidTuple = new UacQidTuple();
     uacQidTuple.setUacQidLink(
-        createNewUacQidPair(linkedCase, calculateQuestionnaireType(linkedCase.getTreatmentCode())));
+        createNewUacQidPair(
+            linkedCase,
+            Integer.toString(calculateQuestionnaireType(linkedCase.getTreatmentCode()))));
     if (packCode.equals(ActionType.P_QU_H2.name())) {
-      uacQidTuple.setUacQidLinkWales(Optional.of(createNewUacQidPair(linkedCase, 3)));
+      uacQidTuple.setUacQidLinkWales(
+          Optional.of(createNewUacQidPair(linkedCase, WALES_IN_WELSH_QUESTIONNAIRE_TYPE)));
     }
     return uacQidTuple;
   }
 
-  private UacQidLink createNewUacQidPair(Case linkedCase, int questionnaireType) {
-    UacQidDTO newUacQidPair =
-        caseClient.getUacQid(linkedCase.getCaseId(), Integer.toString(questionnaireType));
+  private UacQidLink createNewUacQidPair(Case linkedCase, String questionnaireType) {
+    UacQidDTO newUacQidPair = caseClient.getUacQid(linkedCase.getCaseId(), questionnaireType);
     UacQidLink newUacQidLink = new UacQidLink();
     newUacQidLink.setCaseId(linkedCase.getCaseId().toString());
     newUacQidLink.setQid(newUacQidPair.getQid());

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -28,6 +28,11 @@ public enum ActionType {
   P_RL_2RL1_3a(ActionHandler.PRINTER), // 3rd Reminder, Letter - for England addresses
   P_RL_2RL2B_3a(ActionHandler.PRINTER), // 3rd Reminder, Letter - for Wales addresses
 
+  // Reminder questionnaires
+  P_QU_H1(ActionHandler.PRINTER),
+  P_QU_H2(ActionHandler.PRINTER),
+  P_QU_H4(ActionHandler.PRINTER),
+
   // Ad hoc fulfilment requests
   P_OR_HX(ActionHandler.PRINTER), // Household questionnaires
   P_LP_HLX(ActionHandler.PRINTER), // Household questionnaires large print

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
@@ -233,6 +233,9 @@ public class ActionRuleProcessor {
           put("P_RL_1RL2B_2", "P_RL_1RL2B_2");
           put("P_RL_2RL1_3a", "P_RL_2RL1_3a");
           put("P_RL_2RL2B_3a", "P_RL_2RL2B_3a");
+          put("P_QU_H1", "P_QU_H1");
+          put("P_QU_H2", "P_QU_H2");
+          put("P_QU_H4", "P_QU_H4");
         }
       };
 }

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
@@ -30,6 +30,7 @@ import uk.gov.ons.census.action.model.dto.PrintFileDto;
 import uk.gov.ons.census.action.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.action.model.entity.ActionHandler;
 import uk.gov.ons.census.action.model.entity.ActionRule;
+import uk.gov.ons.census.action.model.entity.ActionType;
 import uk.gov.ons.census.action.model.entity.Case;
 import uk.gov.ons.census.action.model.repository.ActionRuleRepository;
 import uk.gov.ons.census.action.model.repository.CustomCaseRepository;
@@ -120,7 +121,7 @@ public class ActionRuleProcessor {
             printFileDtoBuilders.add(
                 () ->
                     printFileDtoBuilder.buildPrintFileDto(
-                        caze, packCode, batchId, triggeredActionRule.getActionType().toString())));
+                        caze, packCode, batchId, triggeredActionRule.getActionType())));
 
     try {
       final int batchQty = printFileDtoBuilders.size();
@@ -220,22 +221,22 @@ public class ActionRuleProcessor {
   private final HashMap<String, String> actionTypeToPackCodeMap =
       new HashMap<>() {
         {
-          put("ICHHQE", "P_IC_H1");
-          put("ICHHQW", "P_IC_H2");
-          put("ICHHQN", "P_IC_H4");
-          put("ICL1E", "P_IC_ICL1");
-          put("ICL2W", "P_IC_ICL2B");
-          put("ICL4N", "P_IC_ICL4");
-          put("P_RL_1RL1_1", "P_RL_1RL1_1");
-          put("P_RL_1RL2B_1", "P_RL_1RL2B_1");
-          put("P_RL_1RL4", "P_RL_1RL4");
-          put("P_RL_1RL1_2", "P_RL_1RL1_2");
-          put("P_RL_1RL2B_2", "P_RL_1RL2B_2");
-          put("P_RL_2RL1_3a", "P_RL_2RL1_3a");
-          put("P_RL_2RL2B_3a", "P_RL_2RL2B_3a");
-          put("P_QU_H1", "P_QU_H1");
-          put("P_QU_H2", "P_QU_H2");
-          put("P_QU_H4", "P_QU_H4");
+          put(ActionType.ICHHQE.name(), "P_IC_H1");
+          put(ActionType.ICHHQW.name(), "P_IC_H2");
+          put(ActionType.ICHHQN.name(), "P_IC_H4");
+          put(ActionType.ICL1E.name(), "P_IC_ICL1");
+          put(ActionType.ICL2W.name(), "P_IC_ICL2B");
+          put(ActionType.ICL4N.name(), "P_IC_ICL4");
+          put(ActionType.P_RL_1RL1_1.name(), ActionType.P_RL_1RL1_1.name());
+          put(ActionType.P_RL_1RL2B_1.name(), ActionType.P_RL_1RL2B_1.name());
+          put(ActionType.P_RL_1RL4.name(), ActionType.P_RL_1RL4.name());
+          put(ActionType.P_RL_1RL1_2.name(), ActionType.P_RL_1RL1_2.name());
+          put(ActionType.P_RL_1RL2B_2.name(), ActionType.P_RL_1RL2B_2.name());
+          put(ActionType.P_RL_2RL1_3a.name(), ActionType.P_RL_2RL1_3a.name());
+          put(ActionType.P_RL_2RL2B_3a.name(), ActionType.P_RL_2RL2B_3a.name());
+          put(ActionType.P_QU_H1.name(), ActionType.P_QU_H1.name());
+          put(ActionType.P_QU_H2.name(), ActionType.P_QU_H2.name());
+          put(ActionType.P_QU_H4.name(), ActionType.P_QU_H4.name());
         }
       };
 }

--- a/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
@@ -2,7 +2,6 @@ package uk.gov.ons.census.action.builders;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,7 +53,7 @@ public class PrintFileDtoBuilderTest {
             testCaze,
             actionTypeToPackCodeMap.get(expectedActionType),
             BATCH_UUID,
-            "test_actiontype");
+            ActionType.ICHHQW);
 
     // Then
     assertThat(actualPrintFileDto).isEqualToComparingFieldByField(expectedPrintFileDto);
@@ -73,7 +72,8 @@ public class PrintFileDtoBuilderTest {
     uacQidTuple.setUacQidLinkWales(Optional.of(welshLink));
 
     QidUacBuilder qidUacBuilder = mock(QidUacBuilder.class);
-    when(qidUacBuilder.getUacQidLinks(any(Case.class), eq(P_IC_ICL1))).thenReturn(uacQidTuple);
+    when(qidUacBuilder.getUacQidLinks(any(Case.class), any(ActionType.class)))
+        .thenReturn(uacQidTuple);
 
     return qidUacBuilder;
   }
@@ -94,7 +94,7 @@ public class PrintFileDtoBuilderTest {
 
     printFileDto.setBatchId(BATCH_UUID.toString());
     printFileDto.setPackCode(actionTypeToPackCodeMap.get(expectedActionType));
-    printFileDto.setActionType("test_actiontype");
+    printFileDto.setActionType(ActionType.ICHHQW.toString());
     printFileDto.setFieldCoordinatorId(caze.getFieldCoordinatorId());
 
     return printFileDto;

--- a/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
@@ -43,7 +43,7 @@ public class PrintFileDtoBuilderTest {
     // Given
     EasyRandom easyRandom = new EasyRandom();
     Case testCaze = easyRandom.nextObject(Case.class);
-    QidUacBuilder uacQidBuilder = getUpQidUacBuilder();
+    QidUacBuilder uacQidBuilder = getQidUacBuilder();
 
     PrintFileDto expectedPrintFileDto = getExpectedPrintFileDto(testCaze);
     PrintFileDtoBuilder printFileDtoBuilder = new PrintFileDtoBuilder(uacQidBuilder);
@@ -60,7 +60,7 @@ public class PrintFileDtoBuilderTest {
     assertThat(actualPrintFileDto).isEqualToComparingFieldByField(expectedPrintFileDto);
   }
 
-  private QidUacBuilder getUpQidUacBuilder() {
+  private QidUacBuilder getQidUacBuilder() {
     UacQidTuple uacQidTuple = new UacQidTuple();
     UacQidLink englishLink = new UacQidLink();
     englishLink.setUac(ENGLISH_UAC);

--- a/src/test/java/uk/gov/ons/census/action/builders/QidUacBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/QidUacBuilderTest.java
@@ -31,7 +31,6 @@ public class QidUacBuilderTest {
 
   private final QidUacBuilder qidUacBuilder = new QidUacBuilder(uacQidLinkRepository, caseClient);
 
-  private static final String TEST_PACK_CODE = "TEST";
   private static final String ENGLISH_QUESTIONNAIRE_TYPE = "01";
   private static final String WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE = "02";
   private static final String WALES_IN_WELSH_QUESTIONNAIRE_TYPE = "03";
@@ -69,7 +68,7 @@ public class QidUacBuilderTest {
             + WALES_TREATMENT_CODE_SUFFIX);
 
     // when
-    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId().toString());
@@ -104,7 +103,7 @@ public class QidUacBuilderTest {
     testCase.setTreatmentCode("NotWelshTreatmentCode");
 
     // when
-    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+    UacQidTuple uacQidTuple = qidUacBuilder.getUacQidLinks(testCase, ActionType.ICL1E);
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId().toString());
@@ -139,7 +138,7 @@ public class QidUacBuilderTest {
         .thenReturn(uacQidLinks);
 
     // When
-    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+    qidUacBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
 
     // Then
     // Exception thrown - expected
@@ -169,10 +168,10 @@ public class QidUacBuilderTest {
         .thenReturn(uacQidLinks);
 
     // When
-    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+    qidUacBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
 
     // Then
-    // Exception thrown - expected
+    // Exception thrown - The second welsh QID must have questionnaire type "03"
   }
 
   @Test(expected = RuntimeException.class)
@@ -209,7 +208,7 @@ public class QidUacBuilderTest {
             + WALES_TREATMENT_CODE_SUFFIX);
 
     // When
-    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+    qidUacBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
 
     // Then
     // Exception thrown - expected
@@ -238,7 +237,7 @@ public class QidUacBuilderTest {
             + WALES_TREATMENT_CODE_SUFFIX);
 
     // When
-    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+    qidUacBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
 
     // Then
     // Exception thrown - expected
@@ -258,7 +257,7 @@ public class QidUacBuilderTest {
         .thenReturn(Collections.EMPTY_LIST);
 
     // When
-    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+    qidUacBuilder.getUacQidLinks(testCase, ActionType.ICL1E);
 
     // Then
     // Exception thrown - expected
@@ -294,14 +293,14 @@ public class QidUacBuilderTest {
         .thenReturn(uacQidLinks);
 
     // When
-    qidUacBuilder.getUacQidLinks(testCase, TEST_PACK_CODE);
+    qidUacBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
 
     // Then
     // Exception thrown - expected
   }
 
   @Test
-  public void testNewUacIsRequestedForReminderLetterPackCode() {
+  public void testNewUacIsRequestedForReminderLetter() {
     // Given
     Case linkedCase = easyRandom.nextObject(Case.class);
     linkedCase.setTreatmentCode("HH_LF2R1E");
@@ -312,7 +311,7 @@ public class QidUacBuilderTest {
 
     // When
     UacQidTuple actualUacQidTuple =
-        qidUacBuilder.getUacQidLinks(linkedCase, reminderLetterPackCode);
+        qidUacBuilder.getUacQidLinks(linkedCase, ActionType.P_RL_1RL1_1);
 
     // Then
     verify(caseClient).getUacQid(eq(linkedCase.getCaseId()), eq(ENGLISH_QUESTIONNAIRE_TYPE));
@@ -334,8 +333,7 @@ public class QidUacBuilderTest {
         .thenReturn(uacQidDTO);
 
     // When
-    UacQidTuple actualUacQidTuple =
-        qidUacBuilder.getUacQidLinks(linkedCase, reminderLetterPackCode);
+    UacQidTuple actualUacQidTuple = qidUacBuilder.getUacQidLinks(linkedCase, ActionType.P_QU_H1);
 
     // Then
     verify(caseClient).getUacQid(eq(linkedCase.getCaseId()), eq(ENGLISH_QUESTIONNAIRE_TYPE));
@@ -359,8 +357,7 @@ public class QidUacBuilderTest {
         .thenReturn(welshUacQidDTO);
 
     // When
-    UacQidTuple actualUacQidTuple =
-        qidUacBuilder.getUacQidLinks(linkedCase, reminderLetterPackCode);
+    UacQidTuple actualUacQidTuple = qidUacBuilder.getUacQidLinks(linkedCase, ActionType.P_QU_H2);
 
     // Then
     verify(caseClient)

--- a/src/test/java/uk/gov/ons/census/action/builders/QidUacBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/QidUacBuilderTest.java
@@ -36,7 +36,6 @@ public class QidUacBuilderTest {
   private static final String WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE = "02";
   private static final String WALES_IN_WELSH_QUESTIONNAIRE_TYPE = "03";
 
-
   private static final EasyRandom easyRandom = new EasyRandom();
 
   @Test
@@ -364,7 +363,8 @@ public class QidUacBuilderTest {
         qidUacBuilder.getUacQidLinks(linkedCase, reminderLetterPackCode);
 
     // Then
-    verify(caseClient).getUacQid(eq(linkedCase.getCaseId()), eq(WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE));
+    verify(caseClient)
+        .getUacQid(eq(linkedCase.getCaseId()), eq(WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE));
     verify(caseClient).getUacQid(eq(linkedCase.getCaseId()), eq(WALES_IN_WELSH_QUESTIONNAIRE_TYPE));
     assertThat(actualUacQidTuple.getUacQidLink())
         .isEqualToComparingOnlyGivenFields(uacQidDTO, "uac", "qid");

--- a/src/test/java/uk/gov/ons/census/action/builders/QidUacBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/QidUacBuilderTest.java
@@ -32,6 +32,11 @@ public class QidUacBuilderTest {
   private final QidUacBuilder qidUacBuilder = new QidUacBuilder(uacQidLinkRepository, caseClient);
 
   private static final String TEST_PACK_CODE = "TEST";
+  private static final String ENGLISH_QUESTIONNAIRE_TYPE = "01";
+  private static final String WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE = "02";
+  private static final String WALES_IN_WELSH_QUESTIONNAIRE_TYPE = "03";
+
+
   private static final EasyRandom easyRandom = new EasyRandom();
 
   @Test
@@ -301,10 +306,9 @@ public class QidUacBuilderTest {
     // Given
     Case linkedCase = easyRandom.nextObject(Case.class);
     linkedCase.setTreatmentCode("HH_LF2R1E");
-    String reminderLetterPackCode = "P_RL_1RL1_1";
-    String expectedQuestionnaireType = "1";
+    String reminderLetterPackCode = ActionType.P_RL_1RL1_1.name();
     UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
-    when(caseClient.getUacQid(eq(linkedCase.getCaseId()), eq(expectedQuestionnaireType)))
+    when(caseClient.getUacQid(eq(linkedCase.getCaseId()), eq(ENGLISH_QUESTIONNAIRE_TYPE)))
         .thenReturn(uacQidDTO);
 
     // When
@@ -312,10 +316,64 @@ public class QidUacBuilderTest {
         qidUacBuilder.getUacQidLinks(linkedCase, reminderLetterPackCode);
 
     // Then
-    verify(caseClient).getUacQid(eq(linkedCase.getCaseId()), eq(expectedQuestionnaireType));
+    verify(caseClient).getUacQid(eq(linkedCase.getCaseId()), eq(ENGLISH_QUESTIONNAIRE_TYPE));
     assertThat(actualUacQidTuple.getUacQidLink())
         .isEqualToComparingOnlyGivenFields(uacQidDTO, "uac", "qid");
     assertThat(actualUacQidTuple.getUacQidLink().getCaseId())
+        .isEqualTo(linkedCase.getCaseId().toString());
+  }
+
+  @Test
+  public void testNewUacIsRequestedForReminderQuestionnaire() {
+    // Given
+    Case linkedCase = easyRandom.nextObject(Case.class);
+    linkedCase.setTreatmentCode("HH_LF2R3BE");
+    String reminderLetterPackCode = ActionType.P_QU_H1.name();
+    String expectedQuestionnaireType = "1";
+    UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
+    when(caseClient.getUacQid(eq(linkedCase.getCaseId()), eq(ENGLISH_QUESTIONNAIRE_TYPE)))
+        .thenReturn(uacQidDTO);
+
+    // When
+    UacQidTuple actualUacQidTuple =
+        qidUacBuilder.getUacQidLinks(linkedCase, reminderLetterPackCode);
+
+    // Then
+    verify(caseClient).getUacQid(eq(linkedCase.getCaseId()), eq(ENGLISH_QUESTIONNAIRE_TYPE));
+    assertThat(actualUacQidTuple.getUacQidLink())
+        .isEqualToComparingOnlyGivenFields(uacQidDTO, "uac", "qid");
+    assertThat(actualUacQidTuple.getUacQidLink().getCaseId())
+        .isEqualTo(linkedCase.getCaseId().toString());
+  }
+
+  @Test
+  public void testNewUacIsRequestedForWelshReminderQuestionnaire() {
+    // Given
+    Case linkedCase = easyRandom.nextObject(Case.class);
+    linkedCase.setTreatmentCode("HH_LF2R3BW");
+    String reminderLetterPackCode = ActionType.P_QU_H2.name();
+    UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
+    UacQidDTO welshUacQidDTO = easyRandom.nextObject(UacQidDTO.class);
+    when(caseClient.getUacQid(eq(linkedCase.getCaseId()), eq(WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE)))
+        .thenReturn(uacQidDTO);
+    when(caseClient.getUacQid(eq(linkedCase.getCaseId()), eq(WALES_IN_WELSH_QUESTIONNAIRE_TYPE)))
+        .thenReturn(welshUacQidDTO);
+
+    // When
+    UacQidTuple actualUacQidTuple =
+        qidUacBuilder.getUacQidLinks(linkedCase, reminderLetterPackCode);
+
+    // Then
+    verify(caseClient).getUacQid(eq(linkedCase.getCaseId()), eq(WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE));
+    verify(caseClient).getUacQid(eq(linkedCase.getCaseId()), eq(WALES_IN_WELSH_QUESTIONNAIRE_TYPE));
+    assertThat(actualUacQidTuple.getUacQidLink())
+        .isEqualToComparingOnlyGivenFields(uacQidDTO, "uac", "qid");
+    assertThat(actualUacQidTuple.getUacQidLink().getCaseId())
+        .isEqualTo(linkedCase.getCaseId().toString());
+    assertThat(actualUacQidTuple.getUacQidLinkWales().isPresent()).isTrue();
+    assertThat(actualUacQidTuple.getUacQidLinkWales().get())
+        .isEqualToComparingOnlyGivenFields(welshUacQidDTO, "uac", "qid");
+    assertThat(actualUacQidTuple.getUacQidLinkWales().get().getCaseId())
         .isEqualTo(linkedCase.getCaseId().toString());
   }
 
@@ -324,10 +382,10 @@ public class QidUacBuilderTest {
     // Given
 
     // When
-    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("HH_LF2R3BE");
+    String actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("HH_LF2R3BE");
 
     // Then
-    assertEquals(1, actualQuestionnaireType);
+    assertEquals("01", actualQuestionnaireType);
   }
 
   @Test
@@ -335,10 +393,10 @@ public class QidUacBuilderTest {
     // Given
 
     // When
-    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("HH_LF2R1W");
+    String actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("HH_LF2R1W");
 
     // Then
-    assertEquals(2, actualQuestionnaireType);
+    assertEquals("02", actualQuestionnaireType);
   }
 
   @Test
@@ -346,10 +404,10 @@ public class QidUacBuilderTest {
     // Given
 
     // When
-    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("HH_1LSFN");
+    String actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("HH_1LSFN");
 
     // Then
-    assertEquals(4, actualQuestionnaireType);
+    assertEquals("04", actualQuestionnaireType);
   }
 
   @Test
@@ -357,10 +415,10 @@ public class QidUacBuilderTest {
     // Given
 
     // When
-    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CI_L666E");
+    String actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CI_L666E");
 
     // Then
-    assertEquals(21, actualQuestionnaireType);
+    assertEquals("21", actualQuestionnaireType);
   }
 
   @Test
@@ -368,10 +426,10 @@ public class QidUacBuilderTest {
     // Given
 
     // When
-    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CI_L666W");
+    String actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CI_L666W");
 
     // Then
-    assertEquals(22, actualQuestionnaireType);
+    assertEquals("22", actualQuestionnaireType);
   }
 
   @Test
@@ -379,10 +437,10 @@ public class QidUacBuilderTest {
     // Given
 
     // When
-    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CI_L666N");
+    String actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CI_L666N");
 
     // Then
-    assertEquals(24, actualQuestionnaireType);
+    assertEquals("24", actualQuestionnaireType);
   }
 
   @Test
@@ -390,10 +448,10 @@ public class QidUacBuilderTest {
     // Given
 
     // When
-    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CE_L666E");
+    String actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CE_L666E");
 
     // Then
-    assertEquals(31, actualQuestionnaireType);
+    assertEquals("31", actualQuestionnaireType);
   }
 
   @Test
@@ -401,10 +459,10 @@ public class QidUacBuilderTest {
     // Given
 
     // When
-    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CE_L666W");
+    String actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CE_L666W");
 
     // Then
-    assertEquals(32, actualQuestionnaireType);
+    assertEquals("32", actualQuestionnaireType);
   }
 
   @Test
@@ -412,10 +470,10 @@ public class QidUacBuilderTest {
     // Given
 
     // When
-    int actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CE_L666N");
+    String actualQuestionnaireType = QidUacBuilder.calculateQuestionnaireType("CE_L666N");
 
     // Then
-    assertEquals(34, actualQuestionnaireType);
+    assertEquals("34", actualQuestionnaireType);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/uk/gov/ons/census/action/builders/QidUacBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/QidUacBuilderTest.java
@@ -326,8 +326,6 @@ public class QidUacBuilderTest {
     // Given
     Case linkedCase = easyRandom.nextObject(Case.class);
     linkedCase.setTreatmentCode("HH_LF2R3BE");
-    String reminderLetterPackCode = ActionType.P_QU_H1.name();
-    String expectedQuestionnaireType = "1";
     UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
     when(caseClient.getUacQid(eq(linkedCase.getCaseId()), eq(ENGLISH_QUESTIONNAIRE_TYPE)))
         .thenReturn(uacQidDTO);
@@ -348,7 +346,6 @@ public class QidUacBuilderTest {
     // Given
     Case linkedCase = easyRandom.nextObject(Case.class);
     linkedCase.setTreatmentCode("HH_LF2R3BW");
-    String reminderLetterPackCode = ActionType.P_QU_H2.name();
     UacQidDTO uacQidDTO = easyRandom.nextObject(UacQidDTO.class);
     UacQidDTO welshUacQidDTO = easyRandom.nextObject(UacQidDTO.class);
     when(caseClient.getUacQid(eq(linkedCase.getCaseId()), eq(WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE)))

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
@@ -59,7 +59,7 @@ public class ActionRuleProcessorTest {
     List<Case> cases = getRandomCases(expectedCaseCount);
 
     when(printFileDtoBuilder.buildPrintFileDto(
-            any(Case.class), any(String.class), any(UUID.class), anyString()))
+            any(Case.class), any(String.class), any(UUID.class), eq(ActionType.ICL1E)))
         .thenReturn(new PrintFileDto());
 
     when(printCaseSelectedBuilder.buildMessage(any(PrintFileDto.class), any(UUID.class)))
@@ -146,7 +146,8 @@ public class ActionRuleProcessorTest {
 
     doThrow(RuntimeException.class)
         .when(printFileDtoBuilder)
-        .buildPrintFileDto(any(Case.class), any(String.class), any(UUID.class), anyString());
+        .buildPrintFileDto(
+            any(Case.class), any(String.class), any(UUID.class), eq(ActionType.ICL1E));
 
     // when
     ActionRuleProcessor actionRuleProcessor =
@@ -188,7 +189,7 @@ public class ActionRuleProcessorTest {
     when(customCaseRepository.streamAll(any(Specification.class))).thenReturn(cases.stream());
 
     when(printFileDtoBuilder.buildPrintFileDto(
-            any(Case.class), any(String.class), any(UUID.class), anyString()))
+            any(Case.class), any(String.class), any(UUID.class), eq(ActionType.ICL1E)))
         .thenReturn(new PrintFileDto());
 
     when(printCaseSelectedBuilder.buildMessage(any(PrintFileDto.class), any(UUID.class)))


### PR DESCRIPTION
# Motivation and Context
We need to send scheduler reminder questionnaires.

# What has changed
* Add action types for reminder questionnaires
* Fetch second welsh UAC QID pair for welsh reminder questionnaire

# How to test?
Build and test with linked branches of print file service and acceptance tests.

# Links
https://trello.com/c/4GUC0HS0/723-rmc-157-schedule-generate-and-distribute-reminder-pqs-5
https://github.com/ONSdigital/census-rm-print-file-service/pull/13