### PR TITLE
No reminders for Household Individual cases.

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
@@ -39,8 +39,6 @@ import uk.gov.ons.census.action.model.repository.CustomCaseRepository;
 public class ActionRuleProcessor {
   private static final Logger log = LoggerFactory.getLogger(ActionRuleScheduler.class);
   private static final ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(50);
-  private static final String ROUTING_KEY_PREFIX = "Action.";
-  private static final String ROUTING_KEY_SUFFIX = ".binding";
   private static final String HOUSEHOLD_INDIVIDUAL = "HI";
 
   private final ActionRuleRepository actionRuleRepo;

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
@@ -39,6 +39,9 @@ import uk.gov.ons.census.action.model.repository.CustomCaseRepository;
 public class ActionRuleProcessor {
   private static final Logger log = LoggerFactory.getLogger(ActionRuleScheduler.class);
   private static final ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(50);
+  private static final String ROUTING_KEY_PREFIX = "Action.";
+  private static final String ROUTING_KEY_SUFFIX = ".binding";
+  private static final String HOUSEHOLD_INDIVIDUAL = "HI";
 
   private final ActionRuleRepository actionRuleRepo;
   private final FieldworkFollowupBuilder fieldworkFollowupBuilder;
@@ -185,7 +188,7 @@ public class ActionRuleProcessor {
 
   private Specification<Case> createSpecificationForActionableCases(String actionPlanId) {
     return where(isActionPlanIdEqualTo(actionPlanId))
-        .and(excludeReceiptedCases().and(excludeRefusedCases()).and(excludeAddressInvalidCases()));
+        .and(excludeReceiptedCases().and(excludeRefusedCases()).and(excludeAddressInvalidCases()).and(excludeHiCases()));
   }
 
   private Specification<Case> isActionPlanIdEqualTo(String actionPlanId) {
@@ -206,6 +209,11 @@ public class ActionRuleProcessor {
   private Specification<Case> excludeAddressInvalidCases() {
     return (Specification<Case>)
         (root, query, builder) -> builder.equal(root.get("addressInvalid"), false);
+  }
+
+  private Specification<Case> excludeHiCases() {
+    return (Specification<Case>)
+            (root, query, builder) -> builder.notEqual(root.get("caseType"), HOUSEHOLD_INDIVIDUAL);
   }
 
   private Specification<Case> isClassifierIn(

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
@@ -188,7 +188,11 @@ public class ActionRuleProcessor {
 
   private Specification<Case> createSpecificationForActionableCases(String actionPlanId) {
     return where(isActionPlanIdEqualTo(actionPlanId))
-        .and(excludeReceiptedCases().and(excludeRefusedCases()).and(excludeAddressInvalidCases()).and(excludeHiCases()));
+        .and(
+            excludeReceiptedCases()
+                .and(excludeRefusedCases())
+                .and(excludeAddressInvalidCases())
+                .and(excludeHiCases()));
   }
 
   private Specification<Case> isActionPlanIdEqualTo(String actionPlanId) {
@@ -213,7 +217,7 @@ public class ActionRuleProcessor {
 
   private Specification<Case> excludeHiCases() {
     return (Specification<Case>)
-            (root, query, builder) -> builder.notEqual(root.get("caseType"), HOUSEHOLD_INDIVIDUAL);
+        (root, query, builder) -> builder.notEqual(root.get("caseType"), HOUSEHOLD_INDIVIDUAL);
   }
 
   private Specification<Case> isClassifierIn(

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleProcessor.java
@@ -188,11 +188,10 @@ public class ActionRuleProcessor {
 
   private Specification<Case> createSpecificationForActionableCases(String actionPlanId) {
     return where(isActionPlanIdEqualTo(actionPlanId))
-        .and(
-            excludeReceiptedCases()
-                .and(excludeRefusedCases())
-                .and(excludeAddressInvalidCases())
-                .and(excludeHiCases()));
+        .and(excludeReceiptedCases())
+        .and(excludeRefusedCases())
+        .and(excludeAddressInvalidCases())
+        .and(excludeHiCases());
   }
 
   private Specification<Case> isActionPlanIdEqualTo(String actionPlanId) {

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -322,7 +322,7 @@ public class ActionRuleProcessorIT {
     return randomCase;
   }
 
-  private Case setUpIndividualCase(ActionPlan actionPlan) {
+  private void setUpIndividualCase(ActionPlan actionPlan) {
     Case randomCase = easyRandom.nextObject(Case.class);
     randomCase.setActionPlanId(actionPlan.getId().toString());
     randomCase.setReceiptReceived(false);
@@ -331,6 +331,5 @@ public class ActionRuleProcessorIT {
     randomCase.setTreatmentCode("HH_LF2R1E");
     randomCase.setCaseType("HI");
     caseRepository.saveAndFlush(randomCase);
-    return randomCase;
   }
 }

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -241,36 +241,36 @@ public class ActionRuleProcessorIT {
     return uacQidDto;
   }
 
-    @Test
-    public void testFieldworkActionRule() throws IOException, InterruptedException {
-        // Given
-        BlockingQueue<String> fieldQueue = rabbitQueueHelper.listen(outboundFieldQueue);
-        BlockingQueue<String> caseSelectedEventQueue = rabbitQueueHelper.listen(actionCaseQueue);
+  @Test
+  public void testFieldworkActionRule() throws IOException, InterruptedException {
+    // Given
+    BlockingQueue<String> fieldQueue = rabbitQueueHelper.listen(outboundFieldQueue);
+    BlockingQueue<String> caseSelectedEventQueue = rabbitQueueHelper.listen(actionCaseQueue);
 
-        ActionPlan actionPlan = setUpActionPlan();
-        Case randomCase = setUpCase(actionPlan);
-        ActionRule actionRule = setUpActionRule(ActionType.FIELD, actionPlan);
+    ActionPlan actionPlan = setUpActionPlan();
+    Case randomCase = setUpCase(actionPlan);
+    ActionRule actionRule = setUpActionRule(ActionType.FIELD, actionPlan);
 
-        // When the action plan triggers
-        String actualMessage = fieldQueue.poll(20, TimeUnit.SECONDS);
-        String actualActionToCaseMessage = caseSelectedEventQueue.poll(20, TimeUnit.SECONDS);
+    // When the action plan triggers
+    String actualMessage = fieldQueue.poll(20, TimeUnit.SECONDS);
+    String actualActionToCaseMessage = caseSelectedEventQueue.poll(20, TimeUnit.SECONDS);
 
-        // Then
-        assertThat(actualMessage).isNotNull();
-        FieldworkFollowup actualFieldworkFollowup =
-                objectMapper.readValue(actualMessage, FieldworkFollowup.class);
-        assertThat(actualFieldworkFollowup.getCaseRef())
-                .isEqualTo(Integer.toString(randomCase.getCaseRef()));
+    // Then
+    assertThat(actualMessage).isNotNull();
+    FieldworkFollowup actualFieldworkFollowup =
+        objectMapper.readValue(actualMessage, FieldworkFollowup.class);
+    assertThat(actualFieldworkFollowup.getCaseRef())
+        .isEqualTo(Integer.toString(randomCase.getCaseRef()));
 
-        assertThat(actualActionToCaseMessage).isNotNull();
-        ResponseManagementEvent actualRmEvent =
-                objectMapper.readValue(actualActionToCaseMessage, ResponseManagementEvent.class);
-        assertThat(actualRmEvent.getEvent().getType()).isEqualTo(EventType.FIELD_CASE_SELECTED);
-        assertThat(actualRmEvent.getPayload().getFieldCaseSelected().getCaseRef())
-                .isEqualTo(randomCase.getCaseRef());
-        assertThat(actualRmEvent.getPayload().getFieldCaseSelected().getActionRuleId())
-                .isEqualTo(actionRule.getId().toString());
-    }
+    assertThat(actualActionToCaseMessage).isNotNull();
+    ResponseManagementEvent actualRmEvent =
+        objectMapper.readValue(actualActionToCaseMessage, ResponseManagementEvent.class);
+    assertThat(actualRmEvent.getEvent().getType()).isEqualTo(EventType.FIELD_CASE_SELECTED);
+    assertThat(actualRmEvent.getPayload().getFieldCaseSelected().getCaseRef())
+        .isEqualTo(randomCase.getCaseRef());
+    assertThat(actualRmEvent.getPayload().getFieldCaseSelected().getActionRuleId())
+        .isEqualTo(actionRule.getId().toString());
+  }
 
   private UacQidDTO stubCreateWelshUacQid() throws JsonProcessingException {
     UacQidDTO welshUacQidDto = easyRandom.nextObject(UacQidDTO.class);

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -213,14 +213,11 @@ public class ActionRuleProcessorIT {
   }
 
   @Test
-  public void testIndividualCaseReminderNotSent()
-          throws IOException, InterruptedException {
-    // Given
-    UacQidDTO uacQidDto = stubCreateUacQid();
-    UacQidDTO welshUacQidDto = stubCreateWelshUacQid();
+  public void testIndividualCaseReminderNotSent() throws InterruptedException {
+    // Given we have an HI case with a valid Treatment Code.
     BlockingQueue<String> printerQueue = rabbitQueueHelper.listen(outboundPrinterQueue);
     ActionPlan actionPlan = setUpActionPlan();
-    Case randomCase = setUpIndividualCase(actionPlan);
+    setUpIndividualCase(actionPlan);
     setUpActionRule(ActionType.P_QU_H2, actionPlan);
 
     // When the action plan triggers


### PR DESCRIPTION
# Motivation and Context
Household Individual cases should not be used for Action reminders.

# What has changed
HI cases are not used when an action rule is triggered.

# How to test?
Run Action scheduler Integration tests.
Build Action Scheduler locally and run acceptance tests against Docker Dev.

# Links
https://trello.com/c/ErIhvPIp/1069-action-rules-to-ignore-hi-cases-3
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/121