### PR TITLE
Fix defect with duplicate UAC QID pairs being created

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
@@ -113,11 +113,19 @@ public class CaseAndUacReceiver {
   }
 
   private void processUacUpdated(Uac uac) {
-    UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setId(UUID.randomUUID());
-    uacQidLink.setQid(uac.getQuestionnaireId());
-    uacQidLink.setUac(uac.getUac());
-    uacQidLink.setCaseId(uac.getCaseId());
+    Optional<UacQidLink> uacQidLinkOpt = uacQidLinkRepository.findByQid(uac.getQuestionnaireId());
+
+    UacQidLink uacQidLink;
+    if (uacQidLinkOpt.isEmpty()) {
+      uacQidLink = new UacQidLink();
+      uacQidLink.setId(UUID.randomUUID());
+      uacQidLink.setQid(uac.getQuestionnaireId());
+      uacQidLink.setUac(uac.getUac());
+      uacQidLink.setCaseId(uac.getCaseId());
+    } else {
+      uacQidLink = uacQidLinkOpt.get();
+    }
+
     uacQidLink.setActive(uac.isActive());
     uacQidLinkRepository.save(uacQidLink);
   }


### PR DESCRIPTION
# Motivation and Context
Duplicate UAC QID pairs being created in Action Scheduler.

# What has changed
Don't create duplicates.

# How to test?
Run acceptance tests.

# Links
Trello: https://trello.com/c/MMPryFN7