### PR TITLE
add msg persistence

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/messaging/ManagedMessageRecoverer.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/ManagedMessageRecoverer.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
 import org.springframework.amqp.rabbit.retry.MessageRecoverer;
@@ -87,6 +88,8 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
       logMessage(
           reportResult, listenerExecutionFailedException.getCause(), messageHash, rawMessageBody);
 
+      // At this point message is not persistent, we need it to be persistent
+      message.getMessageProperties().setDeliveryMode(MessageDeliveryMode.PERSISTENT);
       // Send the bad message to an exchange where it'll be retried at some future point in time
       rabbitTemplate.send(delayExchangeName, queueName, message);
     } else {
@@ -155,14 +158,12 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
 
     // Check if OK and the message is stored... then we can go ahead and quarantine
     if (result) {
-      result = false; // The next bit might go wrong
       log.with("message_hash", messageHash).warn("Skipping message");
 
+      // At this point message is not persistent, we need it to be persistent
+      message.getMessageProperties().setDeliveryMode(MessageDeliveryMode.PERSISTENT);
       // Send the bad message to the quarantine queue
       rabbitTemplate.send(quarantineExchangeName, queueName, message);
-
-      // Presumably the message is now safely quarantined
-      result = true;
     }
 
     return result;


### PR DESCRIPTION
 # Motivation and Context
Msgs sent to delay or delivery weren't set as Persistent, so on a rabbit restart they'd be lost

# What has changed
Make msgs sent to delay or quarantine Persistent, deliveryMode wasn't set by default.
Also removed unneeded bool settings around result.

# How to test?
Build this branch locally, tag it & push to your GCP.  Using rabbit GUI send 2 bad msgs action-scheduler, i.e. case.action.  Then with the toolbox use msgWizard to quarantine 1 of the msgs.  If you now look on the delayedRedeliveryQueue & the quarantineQueue there should be 1 msg on each marked persistent.

Then in your workloads drill into rabbitmq and scale down to 0 from 3.  Then when completed scaling down, scale back up to 3.  Wait till all green then navigate back to the RabbitUI,  there should be a persistent msg in Quarantine and 1 on the delayedRedeliveryQueue queue, unless it's already been sent back to case.action, which is fine
