### PR TITLE
Increase threads available for scheduling

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,11 @@ spring:
     port: 6672
     virtualhost: /
 
+  task:
+    scheduling:
+      pool:
+        size: 2
+
 queueconfig:
   inbound-queue: case.action
   action-fulfilment-inbound-queue: action.fulfilment


### PR DESCRIPTION
# Motivation and Context:
The healthchecks could fail and cause k8s to reboot the action scheduler.

# What has changed?
Increased the size of the thread pool for scheduled jobs.

# How to test?
Hard to reproduce - change is just to be safe.

# Links:
Trello: https://trello.com/c/LheDlxV7