### PR TITLE
Ignore RM internal fulfilment code for HI telephone capture

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/action/service/FulfilmentRequestService.java
@@ -116,7 +116,8 @@ public class FulfilmentRequestService {
       case "UACIT2":
       case "UACIT2W":
       case "UACIT4":
-        return null; // Ignore SMS fulfilments
+      case "RM_TC_HI":
+        return null; // Ignore SMS and RM internal fulfilments
       case "P_OR_I1":
       case "P_OR_I2":
       case "P_OR_I2W":


### PR DESCRIPTION
# Motivation and Context
We have created a new RM internal fulfilment code for individual household telephone capture which action scheduler needs to ignore.

# What has changed
* Add RM_TC_HI to list of ignored fulfilment codes

# How to test?
Build and run this branch with the other branches and acceptance tests for this feature. Check that after the test run, action scheduler has not logged any unknown fulfilment codes.

# Links
https://trello.com/c/UJpW7I1J/484-rmc-335-telephone-capture-hi-13
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/156
https://github.com/ONSdigital/census-rm-case-api/pull/47
https://github.com/ONSdigital/census-rm-case-processor/pull/95