### PR TITLE
Remove case state

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
@@ -11,7 +11,6 @@ import uk.gov.ons.census.action.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.action.model.dto.Uac;
 import uk.gov.ons.census.action.model.entity.ActionType;
 import uk.gov.ons.census.action.model.entity.Case;
-import uk.gov.ons.census.action.model.entity.CaseState;
 import uk.gov.ons.census.action.model.entity.UacQidLink;
 import uk.gov.ons.census.action.model.repository.CaseRepository;
 import uk.gov.ons.census.action.model.repository.UacQidLinkRepository;
@@ -108,7 +107,6 @@ public class CaseAndUacReceiver {
   private void setCaseDetails(CollectionCase collectionCase, Case caseDetails) {
     caseDetails.setCaseRef(Integer.parseInt(collectionCase.getCaseRef()));
     caseDetails.setCaseId(UUID.fromString(collectionCase.getId()));
-    caseDetails.setState(CaseState.valueOf(collectionCase.getState()));
     caseDetails.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
     caseDetails.setAddressLine1(collectionCase.getAddress().getAddressLine1());
     caseDetails.setAddressLine2(collectionCase.getAddress().getAddressLine2());

--- a/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
@@ -10,7 +10,6 @@ public class CollectionCase {
   private String survey;
   private String collectionExerciseId;
   private Address address;
-  private String state;
   private String actionableFrom;
   // Below this line is extra data potentially needed by Action Scheduler - can be ignored by RH
   private String actionPlanId;

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -81,10 +81,6 @@ public class Case {
 
   @Column private String actionPlanId;
 
-  @Column
-  @Enumerated(EnumType.STRING)
-  private CaseState state;
-
   @Column(name = "receipt_received", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean receiptReceived;
 

--- a/src/main/java/uk/gov/ons/census/action/model/entity/CaseState.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/CaseState.java
@@ -1,5 +1,0 @@
-package uk.gov.ons.census.action.model.entity;
-
-public enum CaseState {
-  ACTIONABLE
-}

--- a/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
@@ -20,7 +20,6 @@ import uk.gov.ons.census.action.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.action.model.dto.Uac;
 import uk.gov.ons.census.action.model.entity.ActionType;
 import uk.gov.ons.census.action.model.entity.Case;
-import uk.gov.ons.census.action.model.entity.CaseState;
 import uk.gov.ons.census.action.model.entity.UacQidLink;
 import uk.gov.ons.census.action.model.repository.CaseRepository;
 import uk.gov.ons.census.action.model.repository.UacQidLinkRepository;
@@ -284,7 +283,6 @@ public class CaseAndUacReceiverTest {
         .getCollectionCase()
         .setId("d09ac28e-d62f-4cdd-a5f9-e366e05f0fcd");
     responseManagementEvent.getPayload().getUac().setQuestionnaireId("123");
-    responseManagementEvent.getPayload().getCollectionCase().setState("ACTIONABLE");
     responseManagementEvent.getPayload().getCollectionCase().setReceiptReceived(false);
     responseManagementEvent.getPayload().getCollectionCase().setRefusalReceived(false);
     return responseManagementEvent;
@@ -297,7 +295,6 @@ public class CaseAndUacReceiverTest {
     newCase.setCaseType(collectionCase.getCaseType());
     newCase.setActionPlanId(collectionCase.getActionPlanId());
     newCase.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
-    newCase.setState(CaseState.valueOf(collectionCase.getState()));
     newCase.setTreatmentCode(collectionCase.getTreatmentCode());
     newCase.setAddressLine1(collectionCase.getAddress().getAddressLine1());
     newCase.setAddressLine2(collectionCase.getAddress().getAddressLine2());


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can now safely remove the redundant case `state` column from our schemas

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Removed `state` from the repo

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Make sure tests and acceptance tests still pass from the links below

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/dBJe87ZS/481-get-rid-of-casestate-from-case-table-8

https://github.com/ONSdigital/census-rm-case-processor/pull/101
https://github.com/ONSdigital/census-rm-case-api/pull/53
https://github.com/ONSdigital/census-rm-action-worker/pull/9
https://github.com/ONSdigital/census-rm-ddl/pull/32
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/169