### PR TITLE
caseRef from Integer to Long

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/CaseSelectedBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/CaseSelectedBuilder.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.census.action.model.dto.Event;
 import uk.gov.ons.census.action.model.dto.EventType;
-import uk.gov.ons.census.action.model.dto.FieldCaseSelected;
 import uk.gov.ons.census.action.model.dto.Payload;
 import uk.gov.ons.census.action.model.dto.PrintCaseSelected;
 import uk.gov.ons.census.action.model.dto.PrintFileDto;
@@ -24,18 +23,6 @@ public class CaseSelectedBuilder {
     printCaseSelected.setActionRuleId(actionRuleId);
     printCaseSelected.setCaseRef(printFileDto.getCaseRef());
     printCaseSelected.setPackCode(printFileDto.getPackCode());
-
-    return responseManagementEvent;
-  }
-
-  public ResponseManagementEvent buildFieldMessage(String caseRef, UUID actionRuleId) {
-    ResponseManagementEvent responseManagementEvent =
-        buildEventWithoutPayload(EventType.FIELD_CASE_SELECTED);
-    FieldCaseSelected fieldCaseSelected = new FieldCaseSelected();
-    responseManagementEvent.getPayload().setFieldCaseSelected(fieldCaseSelected);
-
-    fieldCaseSelected.setActionRuleId(actionRuleId.toString());
-    fieldCaseSelected.setCaseRef(Integer.parseInt(caseRef));
 
     return responseManagementEvent;
   }

--- a/src/main/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilder.java
@@ -26,7 +26,7 @@ public class FieldworkFollowupBuilder {
     followup.setActionPlan(actionPlan);
     followup.setActionType(actionType);
     followup.setCaseId(caze.getCaseId().toString());
-    followup.setCaseRef(Integer.toString(caze.getCaseRef()));
+    followup.setCaseRef(Long.toString(caze.getCaseRef()));
     followup.setAddressType(caze.getAddressType());
     followup.setAddressLevel(caze.getAddressLevel());
     followup.setTreatmentCode(caze.getTreatmentCode());

--- a/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
@@ -105,7 +105,7 @@ public class CaseAndUacReceiver {
   }
 
   private void setCaseDetails(CollectionCase collectionCase, Case caseDetails) {
-    caseDetails.setCaseRef(Integer.parseInt(collectionCase.getCaseRef()));
+    caseDetails.setCaseRef(Long.parseLong(collectionCase.getCaseRef()));
     caseDetails.setCaseId(UUID.fromString(collectionCase.getId()));
     caseDetails.setCollectionExerciseId(collectionCase.getCollectionExerciseId());
     caseDetails.setAddressLine1(collectionCase.getAddress().getAddressLine1());

--- a/src/main/java/uk/gov/ons/census/action/messaging/UndeliveredMailReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/UndeliveredMailReceiver.java
@@ -52,7 +52,7 @@ public class UndeliveredMailReceiver {
 
       caseOpt = caseRepository.findByCaseId(UUID.fromString(uacQidLinkOpt.get().getCaseId()));
     } else {
-      int caseRef = Integer.parseInt(event.getPayload().getFulfilmentInformation().getCaseRef());
+      long caseRef = Long.parseLong(event.getPayload().getFulfilmentInformation().getCaseRef());
       caseOpt = caseRepository.findById(caseRef);
     }
 

--- a/src/main/java/uk/gov/ons/census/action/model/dto/FieldCaseSelected.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/FieldCaseSelected.java
@@ -4,6 +4,6 @@ import lombok.Data;
 
 @Data
 public class FieldCaseSelected {
-  private int caseRef;
+  private long caseRef;
   private String actionRuleId;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/PrintCaseSelected.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/PrintCaseSelected.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 public class PrintCaseSelected {
-  private int caseRef;
+  private long caseRef;
   private String packCode;
   private String actionRuleId;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/PrintFileDto.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/PrintFileDto.java
@@ -8,7 +8,7 @@ public class PrintFileDto {
   private String qid;
   private String uacWales;
   private String qidWales;
-  private int caseRef;
+  private long caseRef;
   private String title;
   private String forename;
   private String surname;

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -15,7 +15,7 @@ import lombok.Data;
     })
 public class Case {
 
-  @Id private int caseRef;
+  @Id private long caseRef;
 
   @Column(name = "case_id")
   private UUID caseId;

--- a/src/main/java/uk/gov/ons/census/action/model/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/ons/census/action/model/repository/CaseRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.rest.core.annotation.RestResource;
 import uk.gov.ons.census.action.model.entity.Case;
 
 @RestResource(exported = false)
-public interface CaseRepository
-    extends JpaRepository<Case, Integer>, JpaSpecificationExecutor<Case> {
+public interface CaseRepository extends JpaRepository<Case, Long>, JpaSpecificationExecutor<Case> {
   Optional<Case> findByCaseId(UUID caseId);
 }

--- a/src/test/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilderTest.java
@@ -52,7 +52,7 @@ public class FieldworkFollowupBuilderTest {
     assertThat(actualResult.getUndeliveredAsAddress()).isEqualTo(caze.isUndeliveredAsAddressed());
     assertThat(actualResult.getBlankQreReturned()).isFalse();
     assertThat(actualResult.getCaseId()).isEqualTo(caze.getCaseId().toString());
-    assertThat(actualResult.getCaseRef()).isEqualTo(Integer.toString(caze.getCaseRef()));
+    assertThat(actualResult.getCaseRef()).isEqualTo(Long.toString(caze.getCaseRef()));
     assertThat(actualResult.getHandDelivery()).isEqualTo(caze.isHandDelivery());
     assertThat(actualResult)
         .isEqualToIgnoringGivenFields(

--- a/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
@@ -277,7 +277,7 @@ public class CaseAndUacReceiverTest {
     ResponseManagementEvent responseManagementEvent =
         easyRandom.nextObject(ResponseManagementEvent.class);
 
-    responseManagementEvent.getPayload().getCollectionCase().setCaseRef("123");
+    responseManagementEvent.getPayload().getCollectionCase().setCaseRef("1234567890");
     responseManagementEvent
         .getPayload()
         .getCollectionCase()
@@ -290,7 +290,7 @@ public class CaseAndUacReceiverTest {
 
   private Case getExpectedCase(CollectionCase collectionCase) {
     Case newCase = new Case();
-    newCase.setCaseRef(Integer.parseInt(collectionCase.getCaseRef()));
+    newCase.setCaseRef(Long.parseLong(collectionCase.getCaseRef()));
     newCase.setCaseId(UUID.fromString(collectionCase.getId()));
     newCase.setCaseType(collectionCase.getCaseType());
     newCase.setActionPlanId(collectionCase.getActionPlanId());

--- a/src/test/java/uk/gov/ons/census/action/messaging/UndeliveredMailReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/action/messaging/UndeliveredMailReceiverIT.java
@@ -100,7 +100,7 @@ public class UndeliveredMailReceiverIT {
     responseManagementEvent
         .getPayload()
         .getFulfilmentInformation()
-        .setCaseRef(Integer.toString(caze.getCaseRef()));
+        .setCaseRef(Long.toString(caze.getCaseRef()));
 
     // When
     rabbitQueueHelper.sendMessage(
@@ -123,7 +123,7 @@ public class UndeliveredMailReceiverIT {
 
   private void checkTheThings(FieldworkFollowup actual, Case expected) {
     assertThat(actual.getCaseId()).isEqualTo(expected.getCaseId().toString());
-    assertThat(actual.getCaseRef()).isEqualTo(Integer.toString(expected.getCaseRef()));
+    assertThat(actual.getCaseRef()).isEqualTo(Long.toString(expected.getCaseRef()));
     assertThat(actual.getActionPlan()).isEqualTo("dummy");
     assertThat(actual.getActionType()).isEqualTo("dummy");
     assertThat(actual.getAddressLine1()).isEqualTo(expected.getAddressLine1());

--- a/src/test/java/uk/gov/ons/census/action/messaging/UndeliveredMailReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/action/messaging/UndeliveredMailReceiverTest.java
@@ -84,21 +84,21 @@ public class UndeliveredMailReceiverTest {
     FieldworkFollowup fieldworkFollowup = new FieldworkFollowup();
 
     // Given
-    when(caseRepository.findById((eq(123)))).thenReturn(Optional.of(caze));
+    when(caseRepository.findById((eq(1234567890L)))).thenReturn(Optional.of(caze));
     when(fieldworkFollowupBuilder.buildFieldworkFollowup(eq(caze), eq("dummy"), eq("dummy")))
         .thenReturn(fieldworkFollowup);
 
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
     responseManagementEvent.setPayload(new Payload());
     responseManagementEvent.getPayload().setFulfilmentInformation(new FulfilmentInformation());
-    responseManagementEvent.getPayload().getFulfilmentInformation().setCaseRef("123");
+    responseManagementEvent.getPayload().getFulfilmentInformation().setCaseRef("1234567890");
 
     // When
     underTest.receiveMessage(responseManagementEvent);
 
     // Then
     verify(uacQidLinkRepository, never()).findByQid(any());
-    verify(caseRepository).findById(eq(123));
+    verify(caseRepository).findById(eq(1234567890L));
     verify(fieldworkFollowupBuilder).buildFieldworkFollowup(eq(caze), eq("dummy"), eq("dummy"));
 
     ArgumentCaptor<FieldworkFollowup> ffArgCaptor =
@@ -124,14 +124,14 @@ public class UndeliveredMailReceiverTest {
     FieldworkFollowup fieldworkFollowup = new FieldworkFollowup();
 
     // Given
-    when(caseRepository.findById((eq(123)))).thenReturn(Optional.of(caze));
+    when(caseRepository.findById((eq(1230987654L)))).thenReturn(Optional.of(caze));
     when(fieldworkFollowupBuilder.buildFieldworkFollowup(eq(caze), eq("dummy"), eq("dummy")))
         .thenReturn(fieldworkFollowup);
 
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
     responseManagementEvent.setPayload(new Payload());
     responseManagementEvent.getPayload().setFulfilmentInformation(new FulfilmentInformation());
-    responseManagementEvent.getPayload().getFulfilmentInformation().setCaseRef("123");
+    responseManagementEvent.getPayload().getFulfilmentInformation().setCaseRef("1230987654");
 
     // When
     underTest.receiveMessage(responseManagementEvent);
@@ -158,14 +158,14 @@ public class UndeliveredMailReceiverTest {
     FieldworkFollowup fieldworkFollowup = new FieldworkFollowup();
 
     // Given
-    when(caseRepository.findById((eq(123)))).thenReturn(Optional.of(caze));
+    when(caseRepository.findById((eq(9876543210L)))).thenReturn(Optional.of(caze));
     when(fieldworkFollowupBuilder.buildFieldworkFollowup(eq(caze), eq("dummy"), eq("dummy")))
         .thenReturn(fieldworkFollowup);
 
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
     responseManagementEvent.setPayload(new Payload());
     responseManagementEvent.getPayload().setFulfilmentInformation(new FulfilmentInformation());
-    responseManagementEvent.getPayload().getFulfilmentInformation().setCaseRef("123");
+    responseManagementEvent.getPayload().getFulfilmentInformation().setCaseRef("9876543210");
 
     // When
     underTest.receiveMessage(responseManagementEvent);
@@ -192,7 +192,7 @@ public class UndeliveredMailReceiverTest {
     FieldworkFollowup fieldworkFollowup = new FieldworkFollowup();
 
     // Given
-    when(caseRepository.findById((eq(123)))).thenReturn(Optional.of(caze));
+    when(caseRepository.findById((eq(123L)))).thenReturn(Optional.of(caze));
     when(fieldworkFollowupBuilder.buildFieldworkFollowup(eq(caze), eq("dummy"), eq("dummy")))
         .thenReturn(fieldworkFollowup);
 
@@ -226,7 +226,7 @@ public class UndeliveredMailReceiverTest {
     FieldworkFollowup fieldworkFollowup = new FieldworkFollowup();
 
     // Given
-    when(caseRepository.findById((eq(123)))).thenReturn(Optional.of(caze));
+    when(caseRepository.findById((eq(123L)))).thenReturn(Optional.of(caze));
     when(fieldworkFollowupBuilder.buildFieldworkFollowup(eq(caze), eq("dummy"), eq("dummy")))
         .thenReturn(fieldworkFollowup);
 
@@ -258,7 +258,7 @@ public class UndeliveredMailReceiverTest {
     FieldworkFollowup fieldworkFollowup = new FieldworkFollowup();
 
     // Given
-    when(caseRepository.findById((eq(123)))).thenReturn(Optional.of(caze));
+    when(caseRepository.findById((eq(123L)))).thenReturn(Optional.of(caze));
     when(fieldworkFollowupBuilder.buildFieldworkFollowup(eq(caze), eq("dummy"), eq("dummy")))
         .thenReturn(fieldworkFollowup);
 


### PR DESCRIPTION
# Motivation and Context
caseRef to 10

# What has changed
caseRef becomes a long

# How to test?
with ATs from ticket

# Links
https://trello.com/c/J7ZhdBtv/661-convert-case-ref-from-int-to-long-in-case-api-action-exporter-action-worker-13
# Screenshots (if appropriate):