### PR TITLE
Remove ARID and replace estab ARID with estab UPRN

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilder.java
@@ -17,10 +17,8 @@ public class FieldworkFollowupBuilder {
     followup.setPostcode(caze.getPostcode());
     followup.setEstabType(caze.getEstabType());
     followup.setOrganisationName(caze.getOrganisationName());
-    followup.setArid(caze.getArid());
     followup.setUprn(caze.getUprn());
     followup.setOa(caze.getOa());
-    followup.setArid(caze.getArid());
     followup.setLatitude(caze.getLatitude());
     followup.setLongitude(caze.getLongitude());
     followup.setActionPlan(actionPlan);

--- a/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
@@ -113,7 +113,6 @@ public class CaseAndUacReceiver {
     caseDetails.setAddressLine3(collectionCase.getAddress().getAddressLine3());
     caseDetails.setTownName(collectionCase.getAddress().getTownName());
     caseDetails.setPostcode(collectionCase.getAddress().getPostcode());
-    caseDetails.setArid(collectionCase.getAddress().getArid());
     caseDetails.setLatitude(collectionCase.getAddress().getLatitude());
     caseDetails.setLongitude(collectionCase.getAddress().getLongitude());
     caseDetails.setUprn(collectionCase.getAddress().getUprn());
@@ -128,7 +127,7 @@ public class CaseAndUacReceiver {
     caseDetails.setCaseType(collectionCase.getCaseType());
     caseDetails.setAddressType(collectionCase.getAddress().getAddressType());
     caseDetails.setUprn(collectionCase.getAddress().getUprn());
-    caseDetails.setEstabArid(collectionCase.getAddress().getEstabArid());
+    caseDetails.setEstabUprn(collectionCase.getAddress().getEstabUprn());
     caseDetails.setEstabType(collectionCase.getAddress().getEstabType());
     caseDetails.setOrganisationName(collectionCase.getAddress().getOrganisationName());
     caseDetails.setOa(collectionCase.getOa());

--- a/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
+++ b/src/main/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiver.java
@@ -147,6 +147,7 @@ public class CaseAndUacReceiver {
     caseDetails.setHandDelivery(collectionCase.isHandDelivery());
     caseDetails.setMetadata(collectionCase.getMetadata());
     caseDetails.setSkeleton(collectionCase.isSkeleton());
+    caseDetails.setPrintBatch(collectionCase.getPrintBatch());
     // Yep. Here is a good place to add new stuff.
   }
 

--- a/src/main/java/uk/gov/ons/census/action/model/dto/Address.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/Address.java
@@ -14,8 +14,7 @@ public class Address {
   private String longitude;
   private String uprn;
   private String apbCode;
-  private String arid;
-  private String estabArid;
+  private String estabUprn;
   private String addressType;
   private String addressLevel;
   private String estabType;

--- a/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/CollectionCase.java
@@ -32,4 +32,5 @@ public class CollectionCase {
   private boolean handDelivery;
   private boolean skeleton;
   private CaseMetadata metadata;
+  private String printBatch;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/FieldworkFollowup.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/FieldworkFollowup.java
@@ -12,7 +12,6 @@ public class FieldworkFollowup {
   private String postcode;
   private String estabType;
   private String organisationName;
-  private String arid;
   private String uprn;
   private String oa;
   private String latitude;

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -28,9 +28,7 @@ public class Case {
 
   @Column private String caseType;
 
-  @Column private String arid;
-
-  @Column private String estabArid;
+  @Column private String estabUprn;
 
   @Column private String uprn;
 

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -107,4 +107,6 @@ public class Case {
   @Type(type = "jsonb")
   @Column(columnDefinition = "jsonb")
   private CaseMetadata metadata;
+
+  @Column private String printBatch;
 }

--- a/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
@@ -413,6 +413,7 @@ public class CaseAndUacReceiverTest {
     newCase.setHandDelivery(collectionCase.isHandDelivery());
     newCase.setMetadata(collectionCase.getMetadata());
     newCase.setSkeleton(collectionCase.isSkeleton());
+    newCase.setPrintBatch(collectionCase.getPrintBatch());
     return newCase;
   }
 }

--- a/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/action/messaging/CaseAndUacReceiverTest.java
@@ -388,7 +388,6 @@ public class CaseAndUacReceiverTest {
     newCase.setAddressLine3(collectionCase.getAddress().getAddressLine3());
     newCase.setTownName(collectionCase.getAddress().getTownName());
     newCase.setPostcode(collectionCase.getAddress().getPostcode());
-    newCase.setArid(collectionCase.getAddress().getArid());
     newCase.setLatitude(collectionCase.getAddress().getLatitude());
     newCase.setLongitude(collectionCase.getAddress().getLongitude());
     newCase.setUprn(collectionCase.getAddress().getUprn());
@@ -403,7 +402,7 @@ public class CaseAndUacReceiverTest {
     newCase.setAbpCode(collectionCase.getAddress().getApbCode());
     newCase.setAddressType(collectionCase.getAddress().getAddressType());
     newCase.setUprn(collectionCase.getAddress().getUprn());
-    newCase.setEstabArid(collectionCase.getAddress().getEstabArid());
+    newCase.setEstabUprn(collectionCase.getAddress().getEstabUprn());
     newCase.setEstabType(collectionCase.getAddress().getEstabType());
     newCase.setOrganisationName(collectionCase.getAddress().getOrganisationName());
     newCase.setFieldCoordinatorId(collectionCase.getFieldCoordinatorId());


### PR DESCRIPTION
# Motivation and Context
ARID is dead. Long live ARID. May estab UPRN have a long and victorious reign.

# What has changed
ARID has been removed. Estab ARID has been usurped by Estab UPRN.

# How to test?
Run the ATs along with all the other PRs on the ticket.

# Links
Trello: https://trello.com/c/zm2Ssvnn