### PR TITLE
AM1 Part 4 New Address Fulfilments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,83 @@
-.idea/*
+##############################
+## Java
+##############################
+.mtj.tmp/
+*.class
+*.jar
+*.war
+*.ear
+*.nar
+hs_err_pid*
+
+##############################
+## Maven
+##############################
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+pom.xml.bak
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+##############################
+## Gradle
+##############################
+bin/
+build/
+.gradle
+.gradletasknamecache
+gradle-app.setting
+!gradle-wrapper.jar
+
+##############################
+## IntelliJ
+##############################
+out/
+.idea/
+.idea_modules/
 *.iml
-target/*
+*.ipr
+*.iws
+
+##############################
+## Eclipse
+##############################
+.settings/
+bin/
+tmp/
+.metadata
+.classpath
+.project
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.loadpath
+.factorypath
+
+##############################
+## NetBeans
+##############################
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+
+##############################
+## Visual Studio Code
+##############################
+.vscode/
+
+##############################
+## OS X
+##############################
+.DS_Store

--- a/src/main/java/uk/gov/ons/census/action/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/action/service/FulfilmentRequestService.java
@@ -30,6 +30,20 @@ public class FulfilmentRequestService {
   private final CaseClient caseClient;
   private final CaseSelectedBuilder caseSelectedBuilder;
   private final FulfilmentToSendRepository fulfilmentToSendRepository;
+  private static final Set<String> paperQuestionnaireFulfilmentCodes =
+      Set.of(
+          "P_OR_H1",
+          "P_OR_H2",
+          "P_OR_H2W",
+          "P_OR_H4",
+          "P_OR_HC1",
+          "P_OR_HC2",
+          "P_OR_HC2W",
+          "P_OR_HC4",
+          "P_OR_I1",
+          "P_OR_I2",
+          "P_OR_I2W",
+          "P_OR_I4");
 
   @Value("${queueconfig.outbound-exchange}")
   private String outboundExchange;
@@ -63,19 +77,11 @@ public class FulfilmentRequestService {
     sendFulfilmentToTable(printFileDto, fulfilmentRequest);
   }
 
-  // TODO check list of codes
-  private static final Set<String> paperQuestionnaireFulfilmentCodes =
-      Set.of(
-          "P_OR_H1",
-          "P_OR_H2",
-          "P_OR_H2W",
-          "P_OR_H4",
-          "P_OR_HC1",
-          "P_OR_HC2",
-          "P_OR_HC2W",
-          "P_OR_HC4");
-
-  private void checkMandatoryFields(FulfilmentRequestDTO fulfilmentRequest, Case caze) {
+  private static void checkMandatoryFields(FulfilmentRequestDTO fulfilmentRequest, Case caze) {
+    /*
+    Throws a RuntimeException if the case does not have the minimum data according to the mandatory fields listed here
+    https://collaborate2.ons.gov.uk/confluence/display/SDC/Handle+New+Address+Reported+Events
+     */
     Map<String, Object> mandatoryValues = new HashMap<>();
     mandatoryValues.put("addressLine1", caze.getAddressLine1());
     mandatoryValues.put("postcode", caze.getPostcode());
@@ -101,7 +107,7 @@ public class FulfilmentRequestService {
     }
   }
 
-  private boolean isPaperQuestionnaireFulfilment(FulfilmentRequestDTO fulfilmentRequest) {
+  private static boolean isPaperQuestionnaireFulfilment(FulfilmentRequestDTO fulfilmentRequest) {
     return paperQuestionnaireFulfilmentCodes.contains(fulfilmentRequest.getFulfilmentCode());
   }
 

--- a/src/main/java/uk/gov/ons/census/action/service/FulfilmentRequestService.java
+++ b/src/main/java/uk/gov/ons/census/action/service/FulfilmentRequestService.java
@@ -87,7 +87,7 @@ public class FulfilmentRequestService {
     mandatoryValues.put("postcode", caze.getPostcode());
     mandatoryValues.put("townName", caze.getTownName());
 
-    if (isPaperQuestionnaireFulfilment(fulfilmentRequest) && caze.isHandDelivery()) {
+    if (!isPaperQuestionnaireFulfilment(fulfilmentRequest) && caze.isHandDelivery()) {
       // Non PQ fulfilments which are hand delivered need a field officer and coordinator
       mandatoryValues.put("fieldCoordinatorId", caze.getFieldCoordinatorId());
       mandatoryValues.put("fieldOfficerId", caze.getFieldOfficerId());

--- a/src/test/java/uk/gov/ons/census/action/service/FulfillmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/action/service/FulfillmentRequestServiceTest.java
@@ -86,16 +86,16 @@ public class FulfillmentRequestServiceTest {
   }
 
   @Test(expected = RuntimeException.class)
-  public void testQmFulfilmentForHandDeliverCaseMissingFieldIdsIsRejected() {
+  public void testPpoFulfilmentForHandDeliverCaseMissingFieldIdsIsRejected() {
     FulfilmentRequestDTO fulfilmentRequestDTO = easyRandom.nextObject(FulfilmentRequestDTO.class);
-    fulfilmentRequestDTO.setFulfilmentCode("P_OR_H1");
+    fulfilmentRequestDTO.setFulfilmentCode("P_TB_TBCAN1");
     Case caze = easyRandom.nextObject(Case.class);
     caze.setHandDelivery(true);
     caze.setFieldCoordinatorId(null);
     caze.setFieldOfficerId(null);
 
     try {
-      underTest.processEvent(fulfilmentRequestDTO, caze, ActionType.P_OR_HX);
+      underTest.processEvent(fulfilmentRequestDTO, caze, ActionType.P_TB_TBX);
     } catch (RuntimeException runtimeException) {
       assertThat(runtimeException.getMessage()).contains("fieldOfficerId");
       assertThat(runtimeException.getMessage()).contains("fieldCoordinatorId");

--- a/src/test/java/uk/gov/ons/census/action/service/FulfillmentRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/action/service/FulfillmentRequestServiceTest.java
@@ -85,6 +85,45 @@ public class FulfillmentRequestServiceTest {
     verifyZeroInteractions(caseClient);
   }
 
+  @Test(expected = RuntimeException.class)
+  public void testQmFulfilmentForHandDeliverCaseMissingFieldIdsIsRejected() {
+    FulfilmentRequestDTO fulfilmentRequestDTO = easyRandom.nextObject(FulfilmentRequestDTO.class);
+    fulfilmentRequestDTO.setFulfilmentCode("P_OR_H1");
+    Case caze = easyRandom.nextObject(Case.class);
+    caze.setHandDelivery(true);
+    caze.setFieldCoordinatorId(null);
+    caze.setFieldOfficerId(null);
+
+    try {
+      underTest.processEvent(fulfilmentRequestDTO, caze, ActionType.P_OR_HX);
+    } catch (RuntimeException runtimeException) {
+      assertThat(runtimeException.getMessage()).contains("fieldOfficerId");
+      assertThat(runtimeException.getMessage()).contains("fieldCoordinatorId");
+      assertThat(runtimeException.getMessage()).contains(caze.getCaseId().toString());
+      assertThat(runtimeException.getMessage()).contains(fulfilmentRequestDTO.getFulfilmentCode());
+      throw runtimeException;
+    }
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testCaseMissingMandatoryAddressFieldsIsRejected() {
+    FulfilmentRequestDTO fulfilmentRequestDTO = easyRandom.nextObject(FulfilmentRequestDTO.class);
+    fulfilmentRequestDTO.setFulfilmentCode("P_OR_H1");
+    Case caze = easyRandom.nextObject(Case.class);
+    caze.setAddressLine1(null);
+    caze.setPostcode(null);
+
+    try {
+      underTest.processEvent(fulfilmentRequestDTO, caze, ActionType.P_OR_HX);
+    } catch (RuntimeException runtimeException) {
+      assertThat(runtimeException.getMessage()).contains("addressLine1");
+      assertThat(runtimeException.getMessage()).contains("postcode");
+      assertThat(runtimeException.getMessage()).contains(caze.getCaseId().toString());
+      assertThat(runtimeException.getMessage()).contains(fulfilmentRequestDTO.getFulfilmentCode());
+      throw runtimeException;
+    }
+  }
+
   private void checkCorrectPackCodeAndAddressAreSent(
       FulfilmentRequestDTO fulfilmentRequestDTO,
       Case fulfilmentCase,


### PR DESCRIPTION
# Motivation and Context
Since cases can now be created on the fly with unvalidated potentially incomplete data we now need to protect against fulfilment requests on cases without sufficient address data.

# What has changed
* Add check for mandatory fields in cases being requested for fulfilments
* Add unit tests

# How to test?
Build and run with linked AT's branch.

# Links
https://trello.com/c/C6Y53PdB/709-am1-part-4-new-address-request-paper-fulfilment-5
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/227