### PR TITLE
exclude skeleton cases from action plans

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/schedule/CaseClassifier.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/CaseClassifier.java
@@ -58,6 +58,7 @@ public class CaseClassifier {
     whereClause.append(" AND refusal_received='f'");
     whereClause.append(" AND address_invalid='f'");
     whereClause.append(" AND case_type != 'HI'");
+    whereClause.append(" AND skeleton='f'");
 
     for (Map.Entry<String, List<String>> classifier : classifiers.entrySet()) {
       String inClauseValues =

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -137,6 +137,25 @@ public class ActionRuleProcessorIT {
     assertThat(queuedCases.get(0).getBatchQuantity()).isEqualTo(100);
   }
 
+  @Test
+  public void testCaseDoesNotProcessWhenFlagPresent() throws InterruptedException {
+    // Given
+    ActionPlan actionPlan = setUpActionPlan();
+    setUpCaseWithFlag(actionPlan, "receipt");
+    setUpCaseWithFlag(actionPlan, "refusal");
+    setUpCaseWithFlag(actionPlan, "invalid");
+    setUpCaseWithFlag(actionPlan, "skeleton");
+    setUpCase(actionPlan);
+    setUpActionRule(ActionType.P_QU_H1, actionPlan);
+
+    // When
+    Thread.sleep(2000);
+
+    // Then
+    List<CaseToProcess> queuedCases = caseToProcessRepository.findAll();
+    assertThat(queuedCases.size()).isEqualTo(1);
+  }
+
   private ActionPlan setUpActionPlan() {
     ActionPlan actionPlan = new ActionPlan();
     actionPlan.setId(UUID.randomUUID());
@@ -167,6 +186,7 @@ public class ActionRuleProcessorIT {
     randomCase.setReceiptReceived(false);
     randomCase.setRefusalReceived(false);
     randomCase.setAddressInvalid(false);
+    randomCase.setSkeleton(false);
     randomCase.setTreatmentCode("HH_LF2R1E");
     caseRepository.saveAndFlush(randomCase);
     return randomCase;
@@ -178,6 +198,7 @@ public class ActionRuleProcessorIT {
     randomCase.setReceiptReceived(false);
     randomCase.setRefusalReceived(false);
     randomCase.setAddressInvalid(false);
+    randomCase.setSkeleton(false);
     randomCase.setTreatmentCode("HH_LF2R1E");
     randomCase.setCaseType("HI");
     caseRepository.saveAndFlush(randomCase);
@@ -189,9 +210,36 @@ public class ActionRuleProcessorIT {
     randomCase.setReceiptReceived(false);
     randomCase.setRefusalReceived(false);
     randomCase.setAddressInvalid(false);
+    randomCase.setSkeleton(false);
     randomCase.setTreatmentCode("CE_LDIEE");
     randomCase.setCaseType("CE");
     randomCase.setCeExpectedCapacity(ceExpectedCapacity);
     caseRepository.saveAndFlush(randomCase);
+  }
+
+  private Case setUpCaseWithFlag(ActionPlan actionPlan, String flag) {
+    Case randomCase = easyRandom.nextObject(Case.class);
+    randomCase.setActionPlanId(actionPlan.getId().toString());
+    randomCase.setReceiptReceived(false);
+    randomCase.setRefusalReceived(false);
+    randomCase.setAddressInvalid(false);
+    randomCase.setSkeleton(false);
+    switch (flag) {
+      case "receipt":
+        randomCase.setReceiptReceived(true);
+        break;
+      case "refusal":
+        randomCase.setRefusalReceived(true);
+        break;
+      case "invalid":
+        randomCase.setAddressInvalid(true);
+        break;
+      case "skeleton":
+        randomCase.setSkeleton(true);
+        break;
+    }
+    randomCase.setTreatmentCode("HH_LF2R1E");
+    caseRepository.saveAndFlush(randomCase);
+    return randomCase;
   }
 }

--- a/src/test/java/uk/gov/ons/census/action/schedule/CaseClassifierTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/CaseClassifierTest.java
@@ -42,7 +42,8 @@ public class CaseClassifierTest {
     expectedSql.append("FROM actionv2.cases WHERE action_plan_id='");
     expectedSql.append(actionPlan.getId().toString());
     expectedSql.append("' AND receipt_received='f' AND refusal_received='f' AND ");
-    expectedSql.append("address_invalid='f' AND case_type != 'HI' AND treatment_code IN ");
+    expectedSql.append("address_invalid='f' AND case_type != 'HI' ");
+    expectedSql.append("AND skeleton='f' AND treatment_code IN ");
     expectedSql.append("('abc','xyz')");
     verify(jdbcTemplate)
         .update(eq(expectedSql.toString()), any(UUID.class), eq(actionRule.getId()));
@@ -75,7 +76,8 @@ public class CaseClassifierTest {
     expectedSql.append("FROM actionv2.cases WHERE action_plan_id='");
     expectedSql.append(actionPlan.getId().toString());
     expectedSql.append("' AND receipt_received='f' AND refusal_received='f' AND ");
-    expectedSql.append("address_invalid='f' AND case_type != 'HI' AND treatment_code IN ");
+    expectedSql.append("address_invalid='f' AND case_type != 'HI' ");
+    expectedSql.append("AND skeleton='f' AND treatment_code IN ");
     expectedSql.append("('abc','xyz') GROUP BY case_ref");
     verify(jdbcTemplate)
         .update(eq(expectedSql.toString()), any(UUID.class), eq(actionRule.getId()));


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We don't want skeleton cases to be included when action plans run.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Clause added to statement where rows are excluded if skeleton is true. Tests added and updated.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check branch builds and run alongside [acceptance tests branch of the same name](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/250).
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/ThiV27TP/741-exclude-skeleton-cases-from-action-plans-3
# Screenshots (if appropriate):