### PR TITLE
Fix healthcheck thread starvation causing K8S pod restart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,6 @@
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-integration</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/uk/gov/ons/census/action/Application.java
+++ b/src/main/java/uk/gov/ons/census/action/Application.java
@@ -2,10 +2,8 @@ package uk.gov.ons.census.action;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.integration.annotation.IntegrationComponentScan;
 
 @SpringBootApplication
-@IntegrationComponentScan
 public class Application {
   public static void main(String[] args) {
     SpringApplication.run(Application.class);

--- a/src/main/java/uk/gov/ons/census/action/model/repository/FulfilmentToSendRepository.java
+++ b/src/main/java/uk/gov/ons/census/action/model/repository/FulfilmentToSendRepository.java
@@ -3,10 +3,10 @@ package uk.gov.ons.census.action.model.repository;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.rest.core.annotation.RestResource;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import uk.gov.ons.census.action.model.entity.FulfilmentToProcess;
 
-@RestResource(exported = false)
+@RepositoryRestResource(exported = false)
 public interface FulfilmentToSendRepository extends JpaRepository<FulfilmentToProcess, Long> {
 
   @Query("SELECT DISTINCT f.fulfilmentCode FROM FulfilmentToProcess f")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,11 @@ info:
     version: 1.0
 
 spring:
+  task:
+    scheduling:
+      pool:
+        size: 10
+
   datasource:
     url: jdbc:postgresql://localhost:6432/postgres
     username: postgres
@@ -14,7 +19,7 @@ spring:
     driverClassName: org.postgresql.Driver
     initialization-mode: always
     hikari:
-      maximumPoolSize: 50
+      maximumPoolSize: 10
 
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQL94Dialect


### PR DESCRIPTION
# Motivation and Context
As part of the 'big bang' work I flipped the healthcheck from using Actuator to using the file-based healthcheck, because we don't want to expose the REST API used by the Ops tool in the production environment: we should remove it altogether at some future point, to reduce the attack surface.

When using the file-based healthcheck, which is driven by a scheduled job, there's the possibility of the single thread used by default for scheduling, being blocked by the long-running action rules. This causes K8S to think the application is unhealthy, and therefore will reboot the pod.

I already thought of this issue and implemented a fix for it back in December 2019: https://github.com/ONSdigital/census-rm-action-scheduler/pull/57/files

# What has changed
Increased the number of scheduling threads.

# How to test?
Do a Census.

# Links
Trello: https://trello.com/c/vaiiAIZZ