### PR TITLE
Add action types and update case metadata entity

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -56,6 +56,24 @@ public enum ActionType {
   P_RL_2RL1_3a(ActionHandler.PRINTER), // 3rd Reminder, Letter - for England addresses
   P_RL_2RL2B_3a(ActionHandler.PRINTER), // 3rd Reminder, Letter - for Wales addresses
 
+  // Response driven interventions
+  P_RD_2RL1_1(ActionHandler.PRINTER), // Response driven reminder group 1 English
+  P_RD_2RL2B_1(ActionHandler.PRINTER), // Response driven reminder group 1 Welsh
+  P_RD_2RL1_2(ActionHandler.PRINTER), // Response driven reminder group 2 English
+  P_RD_2RL2B_2(ActionHandler.PRINTER), // Response driven reminder group 2 Welsh
+  P_RD_2RL1_3(ActionHandler.PRINTER), // Response driven reminder group 3 English
+  P_RD_2RL2B_3(ActionHandler.PRINTER), // Response driven reminder group 3 Welsh
+
+  // Response driven reminders for survey launched, no new UACs needed
+  P_RL_1RL1A(ActionHandler.PRINTER),
+  P_RL_1RL2BA(ActionHandler.PRINTER),
+  P_RL_2RL1A(ActionHandler.PRINTER),
+  P_RL_2RL2BA(ActionHandler.PRINTER),
+
+  // Individual response reminders
+  P_RL_1IRL1(ActionHandler.PRINTER),
+  P_RL_1IRL2B(ActionHandler.PRINTER),
+
   // Reminder questionnaires
   P_QU_H1(ActionHandler.PRINTER),
   P_QU_H2(ActionHandler.PRINTER),
@@ -72,21 +90,7 @@ public enum ActionType {
 
   P_UAC_IX(ActionHandler.PRINTER), // Individual response UAC print
 
-  P_ER_IL(ActionHandler.PRINTER), // Information leaflet
-
-  //  response driven interventions
-  P_RD_2RL1_1(ActionHandler.PRINTER), // Response driven reminder group 1 English
-  P_RD_2RL2B_1(ActionHandler.PRINTER), // Response driven reminder group 1 Welsh
-  P_RD_2RL1_2(ActionHandler.PRINTER), // Response driven reminder group 2 English
-  P_RD_2RL2B_2(ActionHandler.PRINTER), // Response driven reminder group 2 Welsh
-  P_RD_2RL1_3(ActionHandler.PRINTER), // Response driven reminder group 3 English
-  P_RD_2RL2B_3(ActionHandler.PRINTER), // Response driven reminder group 3 Welsh
-
-  // response driven reminders for survey launched, no new UACs needed
-  P_RL_1RL1A(ActionHandler.PRINTER),
-  P_RL_1RL2BA(ActionHandler.PRINTER),
-  P_RL_2RL1A(ActionHandler.PRINTER),
-  P_RL_2RL2BA(ActionHandler.PRINTER);
+  P_ER_IL(ActionHandler.PRINTER); // Information leaflet
 
   private final ActionHandler handler;
   private final String packCode;

--- a/src/main/java/uk/gov/ons/census/action/model/entity/CaseMetadata.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/CaseMetadata.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class CaseMetadata {
 
   private Boolean secureEstablishment;
+  private String channel;
 }


### PR DESCRIPTION
# Motivation and Context
The case metadata can now contain the channel of creation for HI cases.

# What has changed
* Add individual reminder action types 
* Update case metadata entity

# How to test?
At AT's PR

# Links
https://trello.com/c/Rc8d1RmE/983-reminders-individual-response-8
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/296