### PR TITLE
1023 address frame delta generate additional initial contact files

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -2,8 +2,6 @@ package uk.gov.ons.census.action.model.entity;
 
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,7 +10,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import lombok.Data;
-import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
@@ -34,7 +31,6 @@ public class ActionRule {
 
   @Column private Boolean hasTriggered;
 
-  @Type(type = "jsonb")
-  @Column(columnDefinition = "jsonb", nullable = false)
-  private Map<String, List<String>> classifiers;
+  @Column(nullable = false)
+  private String userDefinedWhereClause;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -7,6 +7,7 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import lombok.Data;
 
@@ -27,6 +28,7 @@ public class ActionRule {
 
   @Column private Boolean hasTriggered;
 
-  @Column(nullable = false, length = 100000)
+  @Lob
+  @Column(nullable = false)
   private String classifiersClause;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -26,8 +26,7 @@ public class ActionRule {
   private OffsetDateTime triggerDateTime;
 
   @Column private Boolean hasTriggered;
-
-  // This will be set to varchar(max) in the ddl
+  
   @Column(nullable = false, length = 100000)
   private String userDefinedWhereClause;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -26,7 +26,7 @@ public class ActionRule {
   private OffsetDateTime triggerDateTime;
 
   @Column private Boolean hasTriggered;
-  
+
   @Column(nullable = false, length = 100000)
   private String userDefinedWhereClause;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -28,5 +28,5 @@ public class ActionRule {
   @Column private Boolean hasTriggered;
 
   @Column(nullable = false, length = 100000)
-  private String userDefinedWhereClause;
+  private String classifiersClause;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.census.action.model.entity;
 
-import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import javax.persistence.Column;
@@ -10,11 +9,8 @@ import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import lombok.Data;
-import org.hibernate.annotations.TypeDef;
-import org.hibernate.annotations.TypeDefs;
 
 @Entity
-@TypeDefs({@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)})
 @Data
 public class ActionRule {
 
@@ -31,6 +27,7 @@ public class ActionRule {
 
   @Column private Boolean hasTriggered;
 
-  @Column(nullable = false)
+  // This will be set to varchar(max) in the ddl
+  @Column(nullable = false, length = 100000)
   private String userDefinedWhereClause;
 }

--- a/src/main/java/uk/gov/ons/census/action/schedule/CaseClassifier.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/CaseClassifier.java
@@ -64,7 +64,6 @@ public class CaseClassifier {
     whereClause.append(String.format("WHERE action_plan_id='%s'", actionPlanId.toString()));
     whereClause.append(" AND receipt_received='f'");
     whereClause.append(" AND address_invalid='f'");
-    whereClause.append(" AND case_type != 'HI'");
     whereClause.append(" AND skeleton='f'");
 
     if (actionHandler == ActionHandler.PRINTER) {

--- a/src/main/java/uk/gov/ons/census/action/schedule/CaseClassifier.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/CaseClassifier.java
@@ -76,9 +76,12 @@ public class CaseClassifier {
       whereClause.append(" AND refusal_received IS NULL");
     }
 
-    //    This appends the user defined SQL filter e.g. " AND treatment_code IN ('x', 'y', 'z')"
-    //    safety space put in front
-    whereClause.append(" ").append(userDefinedWhereClause);
+    /*
+     " AND " + userDefinedWhereClause, if there's no userDefinedWhereClause (it can't be null) it will cause an error,
+      as the SQL statement will end: " AND "
+      However this may not be bad behaviour, we would always want to a userDefinedWhereClause
+    */
+    whereClause.append(" AND ").append(userDefinedWhereClause);
 
     return whereClause.toString();
   }

--- a/src/main/java/uk/gov/ons/census/action/schedule/CaseClassifier.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/CaseClassifier.java
@@ -39,7 +39,7 @@ public class CaseClassifier {
               + "case_ref, ce_expected_capacity FROM actionv2.cases "
               + buildWhereClause(
                   actionRule.getActionPlan().getId(),
-                  actionRule.getUserDefinedWhereClause(),
+                  actionRule.getClassifiersClause(),
                   actionRule.getActionType().getHandler())
               + " GROUP BY case_ref",
           batchId,
@@ -51,7 +51,7 @@ public class CaseClassifier {
               + "actionv2.cases "
               + buildWhereClause(
                   actionRule.getActionPlan().getId(),
-                  actionRule.getUserDefinedWhereClause(),
+                  actionRule.getClassifiersClause(),
                   actionRule.getActionType().getHandler()),
           batchId,
           actionRule.getId());
@@ -59,7 +59,7 @@ public class CaseClassifier {
   }
 
   private String buildWhereClause(
-      UUID actionPlanId, String userDefinedWhereClause, ActionHandler actionHandler) {
+      UUID actionPlanId, String classifiersClause, ActionHandler actionHandler) {
     StringBuilder whereClause = new StringBuilder();
     whereClause.append(String.format("WHERE action_plan_id='%s'", actionPlanId.toString()));
     whereClause.append(" AND receipt_received='f'");
@@ -76,11 +76,11 @@ public class CaseClassifier {
     }
 
     /*
-     " AND " + userDefinedWhereClause, if there's no userDefinedWhereClause (it can't be null) it will cause an error,
+     " AND " + classifiersclause, if there's no classifiersclause (it can't be null) it will cause an error,
       as the SQL statement will end: " AND "
-      However this may not be bad behaviour, we would always want to a userDefinedWhereClause
+      However this may not be bad behaviour, we would always want to a classifiersclause
     */
-    whereClause.append(" AND ").append(userDefinedWhereClause);
+    whereClause.append(" AND ").append(classifiersClause);
 
     return whereClause.toString();
   }

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -230,7 +230,7 @@ public class ActionRuleProcessorIT {
     actionRule.setHasTriggered(false);
     actionRule.setActionType(actionType);
     actionRule.setActionPlan(actionPlan);
-    actionRule.setUserDefinedWhereClause("case_type != 'HI'");
+    actionRule.setClassifiersClause("case_type != 'HI'");
 
     return actionRuleRepository.saveAndFlush(actionRule);
   }

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -230,7 +230,7 @@ public class ActionRuleProcessorIT {
     actionRule.setHasTriggered(false);
     actionRule.setActionType(actionType);
     actionRule.setActionPlan(actionPlan);
-    actionRule.setUserDefinedWhereClause("1 = 1");
+    actionRule.setUserDefinedWhereClause("case_type != 'HI'");
 
     return actionRuleRepository.saveAndFlush(actionRule);
   }

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -3,9 +3,7 @@ package uk.gov.ons.census.action.schedule;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.OffsetDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.jeasy.random.EasyRandom;
@@ -232,9 +230,7 @@ public class ActionRuleProcessorIT {
     actionRule.setHasTriggered(false);
     actionRule.setActionType(actionType);
     actionRule.setActionPlan(actionPlan);
-
-    Map<String, List<String>> classifiers = new HashMap<>();
-    actionRule.setClassifiers(classifiers);
+    actionRule.setUserDefinedWhereClause("");
 
     return actionRuleRepository.saveAndFlush(actionRule);
   }

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -230,7 +230,7 @@ public class ActionRuleProcessorIT {
     actionRule.setHasTriggered(false);
     actionRule.setActionType(actionType);
     actionRule.setActionPlan(actionPlan);
-    actionRule.setUserDefinedWhereClause("");
+    actionRule.setUserDefinedWhereClause("1 = 1");
 
     return actionRuleRepository.saveAndFlush(actionRule);
   }

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
@@ -6,11 +6,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -28,10 +23,8 @@ public class ActionRuleProcessorTest {
   public void testExecuteClassifiers() {
     // Given
     ActionRule actionRule = setUpActionRule(ActionType.ICL1E);
-    Map<String, List<String>> classifiers = new HashMap<>();
-    List<String> columnValues = Arrays.asList("a", "b", "c");
-    classifiers.put("A_Column", columnValues);
-    actionRule.setClassifiers(classifiers);
+    String userDefinedWhereClause = " AND treatment_code IN ('abc', 'xyz')";
+    actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
 
     // when
     ActionRuleProcessor actionRuleProcessor =
@@ -55,10 +48,9 @@ public class ActionRuleProcessorTest {
     actionRule.setTriggerDateTime(OffsetDateTime.now());
     actionRule.setHasTriggered(false);
 
-    Map<String, List<String>> classifiers = new HashMap<>();
-    classifiers.put("A Key", new ArrayList<>());
+    String userDefinedWhereClause = " AND treatment_code IN ('abc', 'xyz')";
+    actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
 
-    actionRule.setClassifiers(classifiers);
     actionRule.setActionType(actionType);
 
     ActionPlan actionPlan = new ActionPlan();

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
@@ -23,8 +23,6 @@ public class ActionRuleProcessorTest {
   public void testExecuteClassifiers() {
     // Given
     ActionRule actionRule = setUpActionRule(ActionType.ICL1E);
-    String userDefinedWhereClause = "treatment_code IN ('abc', 'xyz')";
-    actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
 
     // when
     ActionRuleProcessor actionRuleProcessor =
@@ -47,9 +45,6 @@ public class ActionRuleProcessorTest {
     actionRule.setId(actionRuleId);
     actionRule.setTriggerDateTime(OffsetDateTime.now());
     actionRule.setHasTriggered(false);
-
-    String userDefinedWhereClause = " treatment_code IN ('abc', 'xyz')";
-    actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
 
     actionRule.setActionType(actionType);
 

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
@@ -23,7 +23,7 @@ public class ActionRuleProcessorTest {
   public void testExecuteClassifiers() {
     // Given
     ActionRule actionRule = setUpActionRule(ActionType.ICL1E);
-    String userDefinedWhereClause = " AND treatment_code IN ('abc', 'xyz')";
+    String userDefinedWhereClause = "treatment_code IN ('abc', 'xyz')";
     actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
 
     // when

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorTest.java
@@ -48,7 +48,7 @@ public class ActionRuleProcessorTest {
     actionRule.setTriggerDateTime(OffsetDateTime.now());
     actionRule.setHasTriggered(false);
 
-    String userDefinedWhereClause = " AND treatment_code IN ('abc', 'xyz')";
+    String userDefinedWhereClause = " treatment_code IN ('abc', 'xyz')";
     actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
 
     actionRule.setActionType(actionType);

--- a/src/test/java/uk/gov/ons/census/action/schedule/CaseClassifierTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/CaseClassifierTest.java
@@ -5,9 +5,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.junit.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -23,14 +20,14 @@ public class CaseClassifierTest {
     JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
 
     CaseClassifier underTest = new CaseClassifier(jdbcTemplate);
-    Map<String, List<String>> classifiers = new HashMap<>();
-    classifiers.put("treatment_code", List.of("abc", "xyz"));
+    String userDefinedWhereClause = " AND treatment_code IN ('abc','xyz')";
+
     ActionPlan actionPlan = new ActionPlan();
     actionPlan.setId(UUID.randomUUID());
     ActionRule actionRule = new ActionRule();
     actionRule.setId(UUID.randomUUID());
     actionRule.setActionPlan(actionPlan);
-    actionRule.setClassifiers(classifiers);
+    actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
     actionRule.setActionType(ActionType.FIELD);
 
     // When
@@ -46,7 +43,7 @@ public class CaseClassifierTest {
     expectedSql.append(" AND address_invalid='f' AND case_type != 'HI'");
     expectedSql.append(" AND skeleton='f'");
     expectedSql.append(" AND refusal_received IS NULL");
-    expectedSql.append(" AND treatment_code IN ('abc','xyz')");
+    expectedSql.append("  AND treatment_code IN ('abc','xyz')");
     verify(jdbcTemplate)
         .update(eq(expectedSql.toString()), any(UUID.class), eq(actionRule.getId()));
   }
@@ -57,14 +54,13 @@ public class CaseClassifierTest {
     JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
 
     CaseClassifier underTest = new CaseClassifier(jdbcTemplate);
-    Map<String, List<String>> classifiers = new HashMap<>();
-    classifiers.put("treatment_code", List.of("abc", "xyz"));
+    String userDefinedWhereClause = " AND treatment_code IN ('abc','xyz')";
     ActionPlan actionPlan = new ActionPlan();
     actionPlan.setId(UUID.randomUUID());
     ActionRule actionRule = new ActionRule();
     actionRule.setId(UUID.randomUUID());
     actionRule.setActionPlan(actionPlan);
-    actionRule.setClassifiers(classifiers);
+    actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
     // Action Type for Printed Reminder Letter
     actionRule.setActionType(ActionType.P_RL_1RL1_1);
 
@@ -81,7 +77,7 @@ public class CaseClassifierTest {
     expectedSql.append(" AND address_invalid='f' AND case_type != 'HI'");
     expectedSql.append(" AND skeleton='f'");
     expectedSql.append(" AND refusal_received IS DISTINCT FROM 'EXTRAORDINARY_REFUSAL'");
-    expectedSql.append(" AND treatment_code IN ('abc','xyz')");
+    expectedSql.append("  AND treatment_code IN ('abc','xyz')");
     verify(jdbcTemplate)
         .update(eq(expectedSql.toString()), any(UUID.class), eq(actionRule.getId()));
   }
@@ -92,14 +88,13 @@ public class CaseClassifierTest {
     JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
 
     CaseClassifier underTest = new CaseClassifier(jdbcTemplate);
-    Map<String, List<String>> classifiers = new HashMap<>();
-    classifiers.put("treatment_code", List.of("abc", "xyz"));
+    String userDefinedWhereClause = " AND treatment_code IN ('abc','xyz')";
     ActionPlan actionPlan = new ActionPlan();
     actionPlan.setId(UUID.randomUUID());
     ActionRule actionRule = new ActionRule();
     actionRule.setId(UUID.randomUUID());
     actionRule.setActionPlan(actionPlan);
-    actionRule.setClassifiers(classifiers);
+    actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
     actionRule.setActionType(ActionType.CE_IC03);
 
     // When
@@ -117,7 +112,7 @@ public class CaseClassifierTest {
     expectedSql.append(" AND case_type != 'HI'");
     expectedSql.append(" AND skeleton='f'");
     expectedSql.append(" AND refusal_received IS DISTINCT FROM 'EXTRAORDINARY_REFUSAL'");
-    expectedSql.append(" AND treatment_code IN ('abc','xyz')");
+    expectedSql.append("  AND treatment_code IN ('abc','xyz')");
     expectedSql.append(" GROUP BY case_ref");
     verify(jdbcTemplate)
         .update(eq(expectedSql.toString()), any(UUID.class), eq(actionRule.getId()));

--- a/src/test/java/uk/gov/ons/census/action/schedule/CaseClassifierTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/CaseClassifierTest.java
@@ -20,14 +20,14 @@ public class CaseClassifierTest {
     JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
 
     CaseClassifier underTest = new CaseClassifier(jdbcTemplate);
-    String userDefinedWhereClause = "treatment_code IN ('abc','xyz')";
+    String classifiersClause = "treatment_code IN ('abc','xyz')";
 
     ActionPlan actionPlan = new ActionPlan();
     actionPlan.setId(UUID.randomUUID());
     ActionRule actionRule = new ActionRule();
     actionRule.setId(UUID.randomUUID());
     actionRule.setActionPlan(actionPlan);
-    actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
+    actionRule.setClassifiersClause(classifiersClause);
     actionRule.setActionType(ActionType.FIELD);
 
     // When
@@ -54,13 +54,13 @@ public class CaseClassifierTest {
     JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
 
     CaseClassifier underTest = new CaseClassifier(jdbcTemplate);
-    String userDefinedWhereClause = "treatment_code IN ('abc','xyz')";
+    String classifiersClause = "treatment_code IN ('abc','xyz')";
     ActionPlan actionPlan = new ActionPlan();
     actionPlan.setId(UUID.randomUUID());
     ActionRule actionRule = new ActionRule();
     actionRule.setId(UUID.randomUUID());
     actionRule.setActionPlan(actionPlan);
-    actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
+    actionRule.setClassifiersClause(classifiersClause);
     // Action Type for Printed Reminder Letter
     actionRule.setActionType(ActionType.P_RL_1RL1_1);
 
@@ -88,13 +88,13 @@ public class CaseClassifierTest {
     JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
 
     CaseClassifier underTest = new CaseClassifier(jdbcTemplate);
-    String userDefinedWhereClause = "treatment_code IN ('abc','xyz')";
+    String classifiersClause = "treatment_code IN ('abc','xyz')";
     ActionPlan actionPlan = new ActionPlan();
     actionPlan.setId(UUID.randomUUID());
     ActionRule actionRule = new ActionRule();
     actionRule.setId(UUID.randomUUID());
     actionRule.setActionPlan(actionPlan);
-    actionRule.setUserDefinedWhereClause(userDefinedWhereClause);
+    actionRule.setClassifiersClause(classifiersClause);
     actionRule.setActionType(ActionType.CE_IC03);
 
     // When

--- a/src/test/java/uk/gov/ons/census/action/schedule/CaseClassifierTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/CaseClassifierTest.java
@@ -40,7 +40,7 @@ public class CaseClassifierTest {
     expectedSql.append(" FROM actionv2.cases WHERE action_plan_id=");
     expectedSql.append("'" + actionPlan.getId().toString() + "'");
     expectedSql.append(" AND receipt_received='f'");
-    expectedSql.append(" AND address_invalid='f' AND case_type != 'HI'");
+    expectedSql.append(" AND address_invalid='f'");
     expectedSql.append(" AND skeleton='f'");
     expectedSql.append(" AND refusal_received IS NULL");
     expectedSql.append(" AND treatment_code IN ('abc','xyz')");
@@ -74,7 +74,7 @@ public class CaseClassifierTest {
     expectedSql.append(" FROM actionv2.cases WHERE action_plan_id=");
     expectedSql.append("'" + actionPlan.getId().toString() + "'");
     expectedSql.append(" AND receipt_received='f'");
-    expectedSql.append(" AND address_invalid='f' AND case_type != 'HI'");
+    expectedSql.append(" AND address_invalid='f'");
     expectedSql.append(" AND skeleton='f'");
     expectedSql.append(" AND refusal_received IS DISTINCT FROM 'EXTRAORDINARY_REFUSAL'");
     expectedSql.append(" AND treatment_code IN ('abc','xyz')");
@@ -109,7 +109,6 @@ public class CaseClassifierTest {
     expectedSql.append("'" + actionPlan.getId().toString() + "'");
     expectedSql.append(" AND receipt_received='f'");
     expectedSql.append(" AND address_invalid='f'");
-    expectedSql.append(" AND case_type != 'HI'");
     expectedSql.append(" AND skeleton='f'");
     expectedSql.append(" AND refusal_received IS DISTINCT FROM 'EXTRAORDINARY_REFUSAL'");
     expectedSql.append(" AND treatment_code IN ('abc','xyz')");

--- a/src/test/java/uk/gov/ons/census/action/schedule/CaseClassifierTest.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/CaseClassifierTest.java
@@ -20,7 +20,7 @@ public class CaseClassifierTest {
     JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
 
     CaseClassifier underTest = new CaseClassifier(jdbcTemplate);
-    String userDefinedWhereClause = " AND treatment_code IN ('abc','xyz')";
+    String userDefinedWhereClause = "treatment_code IN ('abc','xyz')";
 
     ActionPlan actionPlan = new ActionPlan();
     actionPlan.setId(UUID.randomUUID());
@@ -43,7 +43,7 @@ public class CaseClassifierTest {
     expectedSql.append(" AND address_invalid='f' AND case_type != 'HI'");
     expectedSql.append(" AND skeleton='f'");
     expectedSql.append(" AND refusal_received IS NULL");
-    expectedSql.append("  AND treatment_code IN ('abc','xyz')");
+    expectedSql.append(" AND treatment_code IN ('abc','xyz')");
     verify(jdbcTemplate)
         .update(eq(expectedSql.toString()), any(UUID.class), eq(actionRule.getId()));
   }
@@ -54,7 +54,7 @@ public class CaseClassifierTest {
     JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
 
     CaseClassifier underTest = new CaseClassifier(jdbcTemplate);
-    String userDefinedWhereClause = " AND treatment_code IN ('abc','xyz')";
+    String userDefinedWhereClause = "treatment_code IN ('abc','xyz')";
     ActionPlan actionPlan = new ActionPlan();
     actionPlan.setId(UUID.randomUUID());
     ActionRule actionRule = new ActionRule();
@@ -77,7 +77,7 @@ public class CaseClassifierTest {
     expectedSql.append(" AND address_invalid='f' AND case_type != 'HI'");
     expectedSql.append(" AND skeleton='f'");
     expectedSql.append(" AND refusal_received IS DISTINCT FROM 'EXTRAORDINARY_REFUSAL'");
-    expectedSql.append("  AND treatment_code IN ('abc','xyz')");
+    expectedSql.append(" AND treatment_code IN ('abc','xyz')");
     verify(jdbcTemplate)
         .update(eq(expectedSql.toString()), any(UUID.class), eq(actionRule.getId()));
   }
@@ -88,7 +88,7 @@ public class CaseClassifierTest {
     JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
 
     CaseClassifier underTest = new CaseClassifier(jdbcTemplate);
-    String userDefinedWhereClause = " AND treatment_code IN ('abc','xyz')";
+    String userDefinedWhereClause = "treatment_code IN ('abc','xyz')";
     ActionPlan actionPlan = new ActionPlan();
     actionPlan.setId(UUID.randomUUID());
     ActionRule actionRule = new ActionRule();
@@ -112,7 +112,7 @@ public class CaseClassifierTest {
     expectedSql.append(" AND case_type != 'HI'");
     expectedSql.append(" AND skeleton='f'");
     expectedSql.append(" AND refusal_received IS DISTINCT FROM 'EXTRAORDINARY_REFUSAL'");
-    expectedSql.append("  AND treatment_code IN ('abc','xyz')");
+    expectedSql.append(" AND treatment_code IN ('abc','xyz')");
     expectedSql.append(" GROUP BY case_ref");
     verify(jdbcTemplate)
         .update(eq(expectedSql.toString()), any(UUID.class), eq(actionRule.getId()));


### PR DESCRIPTION
# Motivation and Context
Allow filtering on more complex criteria that json classifiers, in this case on date for address frame delta

# What has changed
Rather than take, expect, store and create SQL from json classifiers, this now expects a userDefinedWhereClause, 
e.g. "treatment_code IN ('sdsd')", this is then appended to the hardcoded filters
The hardcoded filter of caseType != 'HI' has also been removed

# How to test?
mvn clean install and with other branches and tests from this ticket

# Links
https://trello.com/c/TnldEmYZ/1023-address-frame-delta-generate-additional-initial-contact-files-13