### PR TITLE
make classfierClause a byte array

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -10,6 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import lombok.Data;
+import org.hibernate.annotations.Type;
 
 @Entity
 @Data
@@ -29,6 +30,15 @@ public class ActionRule {
   @Column private Boolean hasTriggered;
 
   @Lob
+  @Type(type = "org.hibernate.type.BinaryType")
   @Column(nullable = false)
-  private String classifiersClause;
+  private byte[] classifiersClause;
+
+  public void setClassifiersClause(String classifierClauseStr) {
+    classifiersClause = classifierClauseStr.getBytes();
+  }
+
+  public String getClassifiersClause() {
+    return new String(classifiersClause);
+  }
 }


### PR DESCRIPTION
# Motivation and Context
Text column didn't play nicely with ops tool or show nicely in DB

# What has changed
Made column type a Byte Array

# How to test?
Should work nicely with existing ATs (needs action-worker from this ticket installed).  Check that the ops tool works with it, check that the action rules are readable in the database (this wasn't the case with a TEXT column).

# Links
https://trello.com/c/ye66Hup7/1159-make-classifierclause-a-varchar