### PR TITLE
Use UUID type for UUID data

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -83,9 +83,9 @@ public class Case {
 
   @Column private Integer ceActualResponses;
 
-  @Column private String collectionExerciseId;
+  @Column private UUID collectionExerciseId;
 
-  @Column private String actionPlanId;
+  @Column private UUID actionPlanId;
 
   @Column(name = "receipt_received", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean receiptReceived;

--- a/src/main/java/uk/gov/ons/census/action/model/entity/UacQidLink.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/UacQidLink.java
@@ -24,7 +24,7 @@ public class UacQidLink {
   @Column private String uac;
 
   @Column(name = "case_id")
-  private String caseId;
+  private UUID caseId;
 
   @Column private boolean active;
 }

--- a/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
+++ b/src/test/java/uk/gov/ons/census/action/schedule/ActionRuleProcessorIT.java
@@ -241,7 +241,7 @@ public class ActionRuleProcessorIT {
 
   private Case setUpCase(ActionPlan actionPlan) {
     Case randomCase = easyRandom.nextObject(Case.class);
-    randomCase.setActionPlanId(actionPlan.getId().toString());
+    randomCase.setActionPlanId(actionPlan.getId());
     randomCase.setReceiptReceived(false);
     randomCase.setRefusalReceived(null);
     randomCase.setAddressInvalid(false);
@@ -254,7 +254,7 @@ public class ActionRuleProcessorIT {
 
   private void setUpIndividualCase(ActionPlan actionPlan) {
     Case randomCase = easyRandom.nextObject(Case.class);
-    randomCase.setActionPlanId(actionPlan.getId().toString());
+    randomCase.setActionPlanId(actionPlan.getId());
     randomCase.setReceiptReceived(false);
     randomCase.setRefusalReceived(null);
     randomCase.setAddressInvalid(false);
@@ -266,7 +266,7 @@ public class ActionRuleProcessorIT {
 
   private void setUpCeEstabCase(ActionPlan actionPlan, Integer ceExpectedCapacity) {
     Case randomCase = easyRandom.nextObject(Case.class);
-    randomCase.setActionPlanId(actionPlan.getId().toString());
+    randomCase.setActionPlanId(actionPlan.getId());
     randomCase.setReceiptReceived(false);
     randomCase.setRefusalReceived(null);
     randomCase.setAddressInvalid(false);
@@ -279,7 +279,7 @@ public class ActionRuleProcessorIT {
 
   private Case setUpCaseWithFlag(ActionPlan actionPlan, String flag) {
     Case randomCase = easyRandom.nextObject(Case.class);
-    randomCase.setActionPlanId(actionPlan.getId().toString());
+    randomCase.setActionPlanId(actionPlan.getId());
     randomCase.setReceiptReceived(false);
     randomCase.setRefusalReceived(null);
     randomCase.setAddressInvalid(false);


### PR DESCRIPTION
# Motivation and Context
Use UUID data type to hold UUID data

# What has changed
Updated entity and a few tests.

# How to test?
- Build it and run it against the acceptance tests (master), with `use-UUID-type-for-UUId-data` branches of DDL, case-processor, case-api, action-worker and action-processor.

# Links
- https://trello.com/c/r9qwqhaS