### PR TITLE
Log error but don't block other action rules on exception

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -91,7 +91,9 @@ public enum ActionType {
 
   P_UAC_IX(ActionHandler.PRINTER), // Individual response UAC print
 
-  P_ER_IL(ActionHandler.PRINTER); // Information leaflet
+  P_ER_IL(ActionHandler.PRINTER), // Information leaflet
+
+  P_UAC_CX(ActionHandler.PRINTER); // CE Unique Access Codes via paper
 
   private final ActionHandler handler;
   private final String packCode;

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleTriggerer.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleTriggerer.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.census.action.schedule;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -9,6 +11,7 @@ import uk.gov.ons.census.action.model.repository.ActionRuleRepository;
 
 @Component
 public class ActionRuleTriggerer {
+  private static final Logger log = LoggerFactory.getLogger(ActionRuleTriggerer.class);
   private final ActionRuleRepository actionRuleRepo;
   private final ActionRuleProcessor actionRuleProcessor;
 
@@ -24,7 +27,12 @@ public class ActionRuleTriggerer {
         actionRuleRepo.findByTriggerDateTimeBeforeAndHasTriggeredIsFalse(OffsetDateTime.now());
 
     for (ActionRule triggeredActionRule : triggeredActionRules) {
-      actionRuleProcessor.createScheduledActions(triggeredActionRule);
+      try {
+        actionRuleProcessor.createScheduledActions(triggeredActionRule);
+      } catch (Exception e) {
+        log.with("action_rule_id", triggeredActionRule.getId())
+            .error("Stop putting untested SQL into production", e);
+      }
     }
   }
 }

--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleTriggerer.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleTriggerer.java
@@ -31,7 +31,7 @@ public class ActionRuleTriggerer {
         actionRuleProcessor.createScheduledActions(triggeredActionRule);
       } catch (Exception e) {
         log.with("action_rule_id", triggeredActionRule.getId())
-            .error("Stop putting untested SQL into production", e);
+            .error("Unexpected error while executing action rule - is classifier valid SQL?", e);
       }
     }
   }


### PR DESCRIPTION
# Motivation and Context
In the unlikely event that we are free-hand hacking SQL into the action rules in prod, completely untested in preprod, it's _theoretically_ possible that the bad action rule could block other action rules. In practice, this will never happen, because we don't hack rubbish into production in an uncontrolled manner.

In reality, this is a request for a debugger to deal with testers creating bad action rules, not a feature for the Census.

# What has changed
Log an error but don't block other action rules.

# How to test?
Create a bunch of action rules, including a bad one. The bad one shouldn't block the good ones.

# Links
Trello: https://trello.com/c/nWJmBc0D