### PR TITLE
Add useful info logging when rules and fulfilments trigger

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleTriggerer.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/ActionRuleTriggerer.java
@@ -28,6 +28,7 @@ public class ActionRuleTriggerer {
 
     for (ActionRule triggeredActionRule : triggeredActionRules) {
       try {
+        log.with("action_rule_id", triggeredActionRule.getId()).info("Action rule triggered");
         actionRuleProcessor.createScheduledActions(triggeredActionRule);
       } catch (Exception e) {
         log.with("action_rule_id", triggeredActionRule.getId())

--- a/src/main/java/uk/gov/ons/census/action/schedule/FulfilmentProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/FulfilmentProcessor.java
@@ -23,13 +23,15 @@ public class FulfilmentProcessor {
 
   @Transactional
   public void addFulfilmentBatchIdAndQuantity() {
-    UUID batchId = UUID.randomUUID();
-    log.with("batch_id", batchId).info("Fulfilments triggered");
-
     List<String> fulfilmentCodes = fulfilmentToSendRepository.findDistinctFulfilmentCode();
 
     fulfilmentCodes.forEach(
         fulfilmentCode -> {
+          UUID batchId = UUID.randomUUID();
+          log.with("batch_id", batchId)
+              .with("fulfilment_code", fulfilmentCode)
+              .info("Fulfilments triggered");
+
           jdbcTemplate.update(
               "UPDATE actionv2.fulfilment_to_process "
                   + "SET quantity = (SELECT COUNT(*) FROM actionv2.fulfilment_to_process "

--- a/src/main/java/uk/gov/ons/census/action/schedule/FulfilmentProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/FulfilmentProcessor.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.census.action.schedule;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.List;
 import java.util.UUID;
 import javax.transaction.Transactional;
@@ -9,7 +11,7 @@ import uk.gov.ons.census.action.model.repository.FulfilmentToSendRepository;
 
 @Component
 public class FulfilmentProcessor {
-
+  private static final Logger log = LoggerFactory.getLogger(ActionRuleScheduler.class);
   private JdbcTemplate jdbcTemplate;
   private FulfilmentToSendRepository fulfilmentToSendRepository;
 
@@ -21,6 +23,9 @@ public class FulfilmentProcessor {
 
   @Transactional
   public void addFulfilmentBatchIdAndQuantity() {
+    UUID batchId = UUID.randomUUID();
+    log.with("batch_id", batchId).info("Fulfilments triggered");
+
     List<String> fulfilmentCodes = fulfilmentToSendRepository.findDistinctFulfilmentCode();
 
     fulfilmentCodes.forEach(
@@ -30,7 +35,7 @@ public class FulfilmentProcessor {
                   + "SET quantity = (SELECT COUNT(*) FROM actionv2.fulfilment_to_process "
                   + "WHERE fulfilment_code = ?), batch_id = ? WHERE fulfilment_code = ?",
               fulfilmentCode,
-              UUID.randomUUID(),
+              batchId,
               fulfilmentCode);
         });
   }

--- a/src/main/java/uk/gov/ons/census/action/schedule/FulfilmentProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/FulfilmentProcessor.java
@@ -11,7 +11,7 @@ import uk.gov.ons.census.action.model.repository.FulfilmentToSendRepository;
 
 @Component
 public class FulfilmentProcessor {
-  private static final Logger log = LoggerFactory.getLogger(ActionRuleScheduler.class);
+  private static final Logger log = LoggerFactory.getLogger(FulfilmentProcessor.class);
   private JdbcTemplate jdbcTemplate;
   private FulfilmentToSendRepository fulfilmentToSendRepository;
 

--- a/src/main/java/uk/gov/ons/census/action/schedule/FulfilmentScheduler.java
+++ b/src/main/java/uk/gov/ons/census/action/schedule/FulfilmentScheduler.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class FulfilmentScheduler {
   private final FulfilmentProcessor fulfilmentProcessor;
-  private static final Logger log = LoggerFactory.getLogger(ActionRuleScheduler.class);
+  private static final Logger log = LoggerFactory.getLogger(FulfilmentScheduler.class);
 
   public FulfilmentScheduler(FulfilmentProcessor fulfilmentProcessor) {
     this.fulfilmentProcessor = fulfilmentProcessor;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,3 +48,5 @@ fulfilment:
 logging:
   level:
     org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler: ERROR
+    uk.gov.ons.census.action.schedule.ActionRuleTriggerer: INFO
+    uk.gov.ons.census.action.schedule.FulfilmentProcessor: INFO


### PR DESCRIPTION
# Motivation and Context
The action scheduler doesn't do much - most of the work is done by Cloud SQL (Postgres) - and as such, it can be hard to know if it's doing what it's supposed to or not.

# What has changed
Added info logging to the action rules and fulfilments so that we know when they've triggered... although it may take quite a while before the database transaction commits and the action workers spring into action.

# How to test?
Run the ITs and/or ATs and you'll see the extra info logging.

# Links
Trello: https://trello.com/c/g1pelaNc